### PR TITLE
Pass utils as another parameter instead of adding on to context fixes

### DIFF
--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -52,7 +52,7 @@ StyleSheets.prototype.getUnusedReferences = function() {
   return this._styleSheets;
 }
 
-module.exports =  Components.detect(function(context, components) {
+module.exports =  Components.detect(function(context, components, utils) {
   var sourceCode = context.getSourceCode();
   var styleSheets = new StyleSheets();
   var styleReferences = new Set();

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -107,7 +107,7 @@ function componentRule(rule, context) {
   var components = new Components();
 
   // Utilities for component detection
-  context.react = {
+  var utils = {
 
     /**
      * Check if the node is a React ES5 component
@@ -175,9 +175,9 @@ function componentRule(rule, context) {
      */
     getParentComponent: function() {
       return (
-        context.react.getParentES6Component() ||
-        context.react.getParentES5Component() ||
-        context.react.getParentStatelessComponent()
+        utils.getParentES6Component() ||
+        utils.getParentES5Component() ||
+        utils.getParentStatelessComponent()
       );
     },
 
@@ -190,7 +190,7 @@ function componentRule(rule, context) {
       var scope = context.getScope();
       while (scope) {
         var node = scope.block && scope.block.parent && scope.block.parent.parent;
-        if (node && context.react.isES5Component(node)) {
+        if (node && utils.isES5Component(node)) {
           return node;
         }
         scope = scope.upper;
@@ -209,7 +209,7 @@ function componentRule(rule, context) {
         scope = scope.upper;
       }
       var node = scope && scope.block;
-      if (!node || !context.react.isES6Component(node)) {
+      if (!node || !utils.isES6Component(node)) {
         return null;
       }
       return node;
@@ -315,14 +315,14 @@ function componentRule(rule, context) {
   // Component detection instructions
   var detectionInstructions = {
     ClassDeclaration: function(node) {
-      if (!context.react.isES6Component(node)) {
+      if (!utils.isES6Component(node)) {
         return;
       }
       components.add(node, 2);
     },
 
     ClassProperty: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -330,14 +330,14 @@ function componentRule(rule, context) {
     },
 
     ObjectExpression: function(node) {
-      if (!context.react.isES5Component(node)) {
+      if (!utils.isES5Component(node)) {
         return;
       }
       components.add(node, 2);
     },
 
     FunctionExpression: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -345,7 +345,7 @@ function componentRule(rule, context) {
     },
 
     FunctionDeclaration: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -353,11 +353,11 @@ function componentRule(rule, context) {
     },
 
     ArrowFunctionExpression: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
-      if (node.expression && context.react.isReturningJSX(node)) {
+      if (node.expression && utils.isReturningJSX(node)) {
         components.add(node, 2);
       } else {
         components.add(node, 1);
@@ -365,7 +365,7 @@ function componentRule(rule, context) {
     },
 
     ThisExpression: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node || !/Function/.test(node.type)) {
         return;
       }
@@ -374,10 +374,10 @@ function componentRule(rule, context) {
     },
 
     ReturnStatement: function(node) {
-      if (!context.react.isReturningJSX(node)) {
+      if (!utils.isReturningJSX(node)) {
         return;
       }
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -386,7 +386,7 @@ function componentRule(rule, context) {
   };
 
   // Update the provided rule instructions to add the component detection
-  var ruleInstructions = rule(context, components);
+  var ruleInstructions = rule(context, components, utils);
   var updatedRuleInstructions = util._extend({}, ruleInstructions);
   Object.keys(detectionInstructions).forEach(function(instruction) {
     updatedRuleInstructions[instruction] = function(node) {


### PR DESCRIPTION
Fix crash on eslint2.0

```
/home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/eslint.js:765
                    throw ex;
                    ^

TypeError: Error while loading rule 'react-native/no-unused-styles': Can't add property react, object is not extensible
    at Function.componentRule (/home/nils/Programmering/ahead/mobile_app/node_modules/eslint-plugin-react-native/lib/util/Components.js:110:17)
    at /home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/eslint.js:754:25
    at Array.forEach (native)
    at EventEmitter.module.exports.api.verify (/home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/eslint.js:729:16)
    at processText (/home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/cli-engine.js:187:27)
    at processFile (/home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/cli-engine.js:227:18)
    at executeOnFile (/home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/cli-engine.js:602:23)
    at /home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/cli-engine.js:629:17
    at Array.forEach (native)
    at CLIEngine.executeOnFiles (/home/nils/Programmering/ahead/mobile_app/node_modules/eslint/lib/cli-engine.js:624:18)
```
eslintrc.json http://pastebin.com/wpbARaB5

relevant package.json 
```
{
  "devDependencies": {
    "eslint": "^2.0.0-rc.0",
    "eslint-config-airbnb": "^5.0.0",
    "eslint-plugin-react": "^3.16.1",
    "eslint-plugin-react-native": "^0.5.0"
  }
}
```

same issue in eslint-plugin-react
https://github.com/yannickcr/eslint-plugin-react/pull/324
