### PR TITLE
new rules: no-inline-styles, no-color-literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Finally, enable all of the rules that you would like to use.
   "rules": {
     "react-native/no-unused-styles": 2,
     "react-native/split-platform-components": 2,
+    "react-native/no-inline-styles": 2,
+    "react-native/no-color-literals": 2,
   }
 }
 ```
@@ -65,7 +67,8 @@ Finally, enable all of the rules that you would like to use.
 
 * [no-unused-styles](docs/rules/no-unused-styles.md): Detect `StyleSheet` rules which are not used in your React components
 * [split-platform-components](docs/rules/split-platform-components.md): Enforce using platform specific filenames when necessary
-
+* [no-inline-styles](docs/rules/no-inline-styles.md): Detect JSX components with inline styles that contain literal values
+* [no-color-literals](docs/rules/no-color-literals.md): Detect `StyleSheet` rules and inline styles containing color literals instead of variables
 
 [npm-url]: https://npmjs.org/package/eslint-plugin-react-native
 [npm-image]: http://img.shields.io/npm/v/eslint-plugin-react-native.svg?style=flat-square

--- a/docs/rules/no-color-literals.md
+++ b/docs/rules/no-color-literals.md
@@ -1,0 +1,76 @@
+# Detect color literals in styles
+When developing UIs, we often find ourselves reusing the same colors in multiple places in the UI. 
+If the colors have to be updated, they likely have to be updated across the board. So it's good practice
+to store the color definitions in variables instead of hardcoding them inside styles. This rule
+will detect color properties that have literals (ie strings) as values. 
+ 
+The rule looks at all properties that contain `color` (case-insensitive) in their name
+in either `StyleSheet` definitions or JSX properties that have `style` in their name.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+  <Text style={{backgroundColor: '#FFF'}}>Hello</Text>;
+```
+
+```js
+  <View style={{borderBottomColor: 'rgba(255, 125, 125, 0.5)'}}>
+    ...
+  </View>;
+```
+
+```js
+  <Text textStyle={[styles.text, {backgroundColor: '#FFF'}]}>Hello</Text>;
+```
+
+```js
+  <Text style={[styles.text, this.props.something && {backgroundColor: '#000'}]}>Hello</Text>;
+```
+
+```js
+  <Text style={[styles.text, {backgroundColor: this.props.something ? '#FFF' : '#000'}]}>Hello</Text>;
+```
+
+```js
+  const styles = StyleSheet.create({
+    text: {
+      color: 'blue'
+    }
+  });
+```
+
+```js
+  const someVariable = false;
+  const someColorVariable = 'green';
+  const styles = StyleSheet.create({
+    text: {
+      color: someVariable ? 'blue' : someColorVariable
+    }
+  });
+```
+
+
+The following patterns are not considered warnings:
+
+```js
+  const white = '#fff';
+    ...
+  <Text style={{backgroundColor: white}}>Hello</Text>;
+```
+
+```js
+  <View style={{borderBottomColor: this.state.borderBottomColor}}>
+    ...
+  </View>;
+```
+
+```js
+  const $coolBlue = '#00F';
+  const styles = StyleSheet.create({
+    text: {
+      color: $coolBlue
+    }
+  });
+```

--- a/docs/rules/no-inline-styles.md
+++ b/docs/rules/no-inline-styles.md
@@ -1,0 +1,52 @@
+# Detect inline styles in components
+It's (subjectively) good practice to separate styles from the view layout, when possible. 
+This rule detects inline style objects when they contain literal values. If inline styles only contain
+variable values, the style is considered acceptable because it's sometimes necessary to set styles 
+based on `state` or `props`.
+
+## Rule Details
+
+The following pattern is considered a warning:
+
+```js
+const Hello = React.createClass({
+  render: function() {
+    return <Text style={{backgroundColor: '#FFF'}}>Hello {this.props.name}</Text>;
+  }
+});
+```
+
+The following pattern fails only on the `backgroundColor` property, not the `fontSize`:
+
+```js
+const Hello = React.createClass({
+  render: function() {
+    return <Text style={{backgroundColor: '#FFF', fontSize: this.state.fontSize}}>Hello {this.props.name}</Text>;
+  }
+});
+```
+
+The following pattern is not considered a warning:
+```js
+const Hello = React.createClass({
+  render: function() {
+    return <Text style={styles.name}>Hello {this.props.name}</Text>;
+  }
+});
+```
+Any attribute that contains the word `style` is checked for inline object literals. Both of the following
+are considered warnings:
+
+```js
+
+const Hello = React.createClass({
+  render: function() {
+    return <Text style={{fontSize: 12}}>Hello {this.props.name}</Text>;
+  }
+});
+const Welcome = React.createClass({
+  render: function() {
+    return <Text textStyle={{fontSize: 12}}>Welcome</Text>;
+  }
+});
+```

--- a/index.js
+++ b/index.js
@@ -3,10 +3,14 @@
 module.exports = {
   rules: {
     'no-unused-styles': require('./lib/rules/no-unused-styles'),
+    'no-inline-styles': require('./lib/rules/no-inline-styles'),
+    'no-color-literals': require('./lib/rules/no-color-literals'),
     'split-platform-components': require('./lib/rules/split-platform-components')
   },
   rulesConfig: {
     'no-unused-styles': 0,
+    'no-inline-styles': 0,
+    'no-color-literals': 0,
     'split-platform-components': 0
   }
 };

--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Detects color literals
+ * @author Aaron Greenwald
+ */
+'use strict';
+const util = require('util');
+const Components = require('../util/Components');
+const styleSheet = require('../util/stylesheet');
+const StyleSheets = styleSheet.StyleSheets;
+const astHelpers = styleSheet.astHelpers;
+
+module.exports = Components.detect(context => {
+  const styleSheets = new StyleSheets();
+
+  function reportColorLiterals(colorLiterals) {
+    if (colorLiterals) {
+      colorLiterals.forEach(style => {
+        if (style) {
+          const expression = util.inspect(style.expression);
+          context.report({
+            node: style.node,
+            message: 'Color literal: {{expression}}',
+            data: { expression },
+          });
+        }
+      });
+    }
+  }
+
+  return {
+    VariableDeclarator: node => {
+      if (astHelpers.isStyleSheetDeclaration(node)) {
+        const styles = astHelpers.getStyleDeclarations(node);
+
+        if (styles) {
+          styles.forEach(style => {
+            const literals = astHelpers.collectColorLiterals(style.value, context);
+            styleSheets.addColorLiterals(literals);
+          });
+        }
+      }
+    },
+
+    JSXAttribute: node => {
+      if (astHelpers.isStyleAttribute(node)) {
+        const literals = astHelpers.collectColorLiterals(node.value, context);
+        styleSheets.addColorLiterals(literals);
+      }
+    },
+
+    'Program:exit': () => reportColorLiterals(styleSheets.getColorLiterals()),
+  };
+});
+
+module.exports.schema = [];

--- a/lib/rules/no-inline-styles.js
+++ b/lib/rules/no-inline-styles.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Detects inline styles
+ * @author Aaron Greenwald
+ */
+'use strict';
+const util = require('util');
+const Components = require('../util/Components');
+const styleSheet = require('../util/stylesheet');
+const StyleSheets = styleSheet.StyleSheets;
+const astHelpers = styleSheet.astHelpers;
+
+module.exports = Components.detect(context => {
+  const styleSheets = new StyleSheets();
+
+  function reportInlineStyles(inlineStyles) {
+    if (inlineStyles) {
+      inlineStyles.forEach(style => {
+        if (style) {
+          const expression = util.inspect(style.expression);
+          context.report({
+            node: style.node,
+            message: 'Inline style: {{expression}}',
+            data: { expression },
+          });
+        }
+      });
+    }
+  }
+
+  return {
+    JSXAttribute: node => {
+      if (astHelpers.isStyleAttribute(node)) {
+        const styles = astHelpers.collectStyleObjectExpressions(node.value, context);
+        styleSheets.addObjectExpressions(styles);
+      }
+    },
+
+    'Program:exit': () => reportInlineStyles(styleSheets.getObjectExpressions()),
+  };
+});
+
+module.exports.schema = [];

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -345,6 +345,12 @@ const astHelpers = {
             invalid = true;
             obj[p.key.name] = _getSourceCode(innerNode);
           }
+        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '-') {
+          invalid = true;
+          obj[p.key.name] = -1 * p.value.argument.value;
+        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '+') {
+          invalid = true;
+          obj[p.key.name] = p.value.argument.value;
         }
       });
     }

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -31,18 +31,65 @@ StyleSheets.prototype.markAsUsed = function (fullyQualifiedName) {
 
   if (this._styleSheets[styleSheetName]) {
     this._styleSheets[styleSheetName] = this
-      ._styleSheets[styleSheetName]
-      .filter((property) => property.key.name !== styleSheetProperty);
+        ._styleSheets[styleSheetName]
+        .filter((property) => property.key.name !== styleSheetProperty);
   }
 };
 
 /**
-* GetUnusedReferences returns all collected StyleSheets and their
-* unmarked rules.
-*/
+ * GetUnusedReferences returns all collected StyleSheets and their
+ * unmarked rules.
+ */
 StyleSheets.prototype.getUnusedReferences = function () {
   return this._styleSheets;
 };
+
+/**
+ * AddColorLiterals adds an array of expressions that contain color literals
+ * to the ColorLiterals collection
+ * @param {array} expressions - an array of expressions containing color literals
+ */
+StyleSheets.prototype.addColorLiterals = function (expressions) {
+  if (!this._colorLiterals) {
+    this._colorLiterals = [];
+  }
+  this._colorLiterals = this._colorLiterals.concat(expressions);
+};
+
+/**
+ * GetColorLiterals returns an array of collected color literals expressions
+ * @returns {Array}
+ */
+StyleSheets.prototype.getColorLiterals = function () {
+  return this._colorLiterals;
+};
+
+/**
+ * AddObjectexpressions adds an array of expressions to the ObjectExpressions collection
+ * @param {Array} expressions - an array of expressions containing ObjectExpressions in
+ * inline styles
+ */
+StyleSheets.prototype.addObjectExpressions = function (expressions) {
+  if (!this._objectExpressions) {
+    this._objectExpressions = [];
+  }
+  this._objectExpressions = this._objectExpressions.concat(expressions);
+};
+
+/**
+ * GetObjectExpressions returns an array of collected object expressiosn used in inline styles
+ * @returns {Array}
+ */
+StyleSheets.prototype.getObjectExpressions = function () {
+  return this._objectExpressions;
+};
+
+
+let _context;
+const _getSourceCode = node => _context
+  .getSourceCode(node)
+  .getText(node)
+;
 
 const astHelpers = {
   containsStyleSheetObject: function (node) {
@@ -121,13 +168,66 @@ const astHelpers = {
     return astHelpers.getStyleReferenceFromNode(node.expression);
   },
 
+  collectStyleObjectExpressions: function (node, context) {
+    _context = context;
+    if (astHelpers.hasArrayOfStyleReferences(node)) {
+      const styleReferenceContainers = node
+          .expression
+          .elements;
+
+      return astHelpers.collectStyleObjectExpressionFromContainers(
+          styleReferenceContainers
+      );
+    }
+
+    return astHelpers.getStyleObjectExpressionFromNode(node.expression);
+  },
+
+  collectColorLiterals: function (node, context) {
+    _context = context;
+    if (astHelpers.hasArrayOfStyleReferences(node)) {
+      const styleReferenceContainers = node
+          .expression
+          .elements;
+
+      return astHelpers.collectColorLiteralsFromContainers(
+          styleReferenceContainers
+      );
+    }
+
+    if (node.type === 'ObjectExpression') {
+      return astHelpers.getColorLiteralsFromNode(node);
+    }
+
+    return astHelpers.getColorLiteralsFromNode(node.expression);
+  },
+
   collectStyleReferencesFromContainers: function (nodes) {
     let styleReferences = [];
-    nodes.forEach((node) => {
+    nodes.forEach(node => {
       styleReferences = styleReferences.concat(astHelpers.getStyleReferenceFromNode(node));
     });
-
     return styleReferences;
+  },
+
+  collectStyleObjectExpressionFromContainers: function (nodes) {
+    let objectExpressions = [];
+    nodes.forEach(node => {
+      objectExpressions = objectExpressions
+          .concat(astHelpers.getStyleObjectExpressionFromNode(node));
+    });
+
+    return objectExpressions;
+  },
+
+  collectColorLiteralsFromContainers: function (nodes) {
+    let colorLiterals = [];
+    nodes.forEach(node => {
+      colorLiterals = colorLiterals
+          .concat(astHelpers.getColorLiteralsFromNode(node));
+    });
+
+    return colorLiterals;
   },
 
   getStyleReferenceFromNode: function (node) {
@@ -156,6 +256,58 @@ const astHelpers = {
     }
   },
 
+  getStyleObjectExpressionFromNode: function (node) {
+    let leftStyleObjectExpression;
+    let rightStyleObjectExpression;
+
+    if (!node) {
+      return [];
+    }
+
+    if (node.type === 'ObjectExpression') {
+      return [astHelpers.getStyleObjectFromExpression(node)];
+    }
+
+    switch (node.type) {
+      case 'LogicalExpression':
+        leftStyleObjectExpression = astHelpers.getStyleObjectExpressionFromNode(node.left);
+        rightStyleObjectExpression = astHelpers.getStyleObjectExpressionFromNode(node.right);
+        return [].concat(leftStyleObjectExpression).concat(rightStyleObjectExpression);
+      case 'ConditionalExpression':
+        leftStyleObjectExpression = astHelpers.getStyleObjectExpressionFromNode(node.consequent);
+        rightStyleObjectExpression = astHelpers.getStyleObjectExpressionFromNode(node.alternate);
+        return [].concat(leftStyleObjectExpression).concat(rightStyleObjectExpression);
+      default:
+        return [];
+    }
+  },
+
+  getColorLiteralsFromNode: function (node) {
+    let leftColorLiterals;
+    let rightColorLiterals;
+
+    if (!node) {
+      return [];
+    }
+
+    if (node.type === 'ObjectExpression') {
+      return [astHelpers.getColorLiteralsFromExpression(node)];
+    }
+
+    switch (node.type) {
+      case 'LogicalExpression':
+        leftColorLiterals = astHelpers.getColorLiteralsFromNode(node.left);
+        rightColorLiterals = astHelpers.getColorLiteralsFromNode(node.right);
+        return [].concat(leftColorLiterals).concat(rightColorLiterals);
+      case 'ConditionalExpression':
+        leftColorLiterals = astHelpers.getColorLiteralsFromNode(node.consequent);
+        rightColorLiterals = astHelpers.getColorLiteralsFromNode(node.alternate);
+        return [].concat(leftColorLiterals).concat(rightColorLiterals);
+      default:
+        return [];
+    }
+  },
+
   hasArrayOfStyleReferences: function (node) {
     return Boolean(
       node.type === 'JSXExpressionContainer' &&
@@ -177,6 +329,48 @@ const astHelpers = {
     }
 
     return result.join('.');
+  },
+
+  getStyleObjectFromExpression: function (node) {
+    const obj = {};
+    let invalid = false;
+    if (node.properties && node.properties.length) {
+      node.properties.forEach(p => {
+        if (p.value.type === 'Literal') {
+          invalid = true;
+          obj[p.key.name] = p.value.value;
+        } else if (p.value.type === 'ConditionalExpression') {
+          const innerNode = p.value;
+          if (innerNode.consequent.type === 'Literal' || innerNode.alternate.type === 'Literal') {
+            invalid = true;
+            obj[p.key.name] = _getSourceCode(innerNode);
+          }
+        }
+      });
+    }
+    return invalid ? { expression: obj, node: node } : undefined;
+  },
+
+  getColorLiteralsFromExpression: function (node) {
+    const obj = {};
+    let invalid = false;
+    if (node.properties && node.properties.length) {
+      node.properties.forEach(p => {
+        if (p.key.name.toLowerCase().indexOf('color') !== -1) {
+          if (p.value.type === 'Literal') {
+            invalid = true;
+            obj[p.key.name] = p.value.value;
+          } else if (p.value.type === 'ConditionalExpression') {
+            const innerNode = p.value;
+            if (innerNode.consequent.type === 'Literal' || innerNode.alternate.type === 'Literal') {
+              invalid = true;
+              obj[p.key.name] = _getSourceCode(innerNode);
+            }
+          }
+        }
+      });
+    }
+    return invalid ? { expression: obj, node: node } : undefined;
   },
 
   getObjectName: function (node) {

--- a/tests/lib/rules/no-color-literals.js
+++ b/tests/lib/rules/no-color-literals.js
@@ -1,0 +1,192 @@
+/**
+ * @fileoverview No color literals used in styles
+ * @author Aaron Greenwald
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-color-literals');
+const RuleTester = require('eslint').RuleTester;
+
+require('babel-eslint');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+const tests = {
+  valid: [
+    {
+      code: [
+        'const $red = \'red\'',
+        'const $blue = \'blue\'',
+        'const styles = StyleSheet.create({',
+        '    style1: {',
+        '        color: $red,',
+        '    },',
+        '    style2: {',
+        '        color: $blue,',
+        '    }',
+        '});',
+        'export default class MyComponent extends Component {',
+        '    render() {',
+        '        const isDanger = true;',
+        '        return <View ',
+        '                   style={[styles.style1, isDanger ? styles.style1 : styles.style2]}',
+        '               />;',
+        '    }',
+        '}',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'const styles = StyleSheet.create({',
+        '    style1: {',
+        '        color: $red,',
+        '    },',
+        '    style2: {',
+        '        color: $blue,',
+        '    }',
+        '});',
+        'export default class MyComponent extends Component {',
+        '    render() {',
+        '        const trueColor = \'#fff\';',
+        '        const falseColor = \'#000\' ',
+        '        return <View ',
+        '           style={[style1, ',
+        '                   this.state.isDanger && {color: falseColor}, ',
+        '                   {color: someBoolean ? trueColor : falseColor }]} ',
+        '                />;',
+        '    }',
+        '}',
+      ].join('\n'),
+    },
+  ],
+  invalid: [
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: 0.5}}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: this.state.opacity}}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
+      }],
+    },
+    {
+      code: [
+        'const styles = StyleSheet.create({',
+        '  text: {fontColor: \'#000\'}',
+        '})',
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={{opacity: this.state.opacity, height: 12, fontColor: styles.text}}>', //eslint-disable-line
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Color literal: { fontColor: \'#000\' }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={[styles.text, {backgroundColor: \'#FFFFFF\'}]}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    const someBoolean = false; ',
+        '    return <Text style={[styles.text, someBoolean && {backgroundColor: \'#FFFFFF\'}]}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
+      }],
+    },
+    {
+      code: [
+        'const styles = StyleSheet.create({',
+        '    style1: {',
+        '        color: \'red\',',
+        '    },',
+        // this is illegal even though it's not used anywhere
+        '    style2: {',
+        '        borderBottomColor: \'blue\',',
+        '    }',
+        '});',
+        'export default class MyComponent extends Component {',
+        '    render() {',
+        '        return <View ',
+        '           style={[style1, ',
+        '                   this.state.isDanger && styles.style1, ',
+        '                   {backgroundColor: someBoolean ? \'#fff\' : \'#000\'}]} ',
+        '                />;',
+        '    }',
+        '}',
+      ].join('\n'),
+      errors: [
+        {
+          message: 'Color literal: { color: \'red\' }',
+        },
+        {
+          message: 'Color literal: { borderBottomColor: \'blue\' }',
+        },
+        {
+          message: 'Color literal: { backgroundColor: \'someBoolean ? \\\'#fff\\\' : \\\'#000\\\'\' }', //eslint-disable-line
+        },
+      ],
+    },
+  ],
+};
+
+const config = {
+  parser: 'babel-eslint',
+  ecmaFeatures: {
+    classes: true,
+    jsx: true,
+  },
+};
+
+tests.valid.forEach(t => Object.assign(t, config));
+tests.invalid.forEach(t => Object.assign(t, config));
+
+ruleTester.run('no-color-literals', rule, tests);

--- a/tests/lib/rules/no-inline-styles.js
+++ b/tests/lib/rules/no-inline-styles.js
@@ -1,0 +1,179 @@
+/**
+ * @fileoverview No inline styles defined in javascript files
+ * @author Aaron Greenwald
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-inline-styles');
+const RuleTester = require('eslint').RuleTester;
+
+require('babel-eslint');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+
+const tests = {
+
+  valid: [
+    {
+      code: [
+        'const styles = StyleSheet.create({',
+        '    style1: {',
+        '        color: \'red\',',
+        '    },',
+        '    style2: {',
+        '        color: \'blue\',',
+        '    }',
+        '});',
+        'export default class MyComponent extends Component {',
+        '    static propTypes = {',
+        '        isDanger: PropTypes.bool',
+        '    };',
+        '    render() {',
+        '        return <View style={this.props.isDanger ? styles.style1 : styles.style2} />;',
+        '    }',
+        '}',
+      ].join('\n'),
+    },
+    {
+      code: [
+        'const styles = StyleSheet.create({',
+        '    style1: {',
+        '        color: \'red\',',
+        '    },',
+        '    style2: {',
+        '        color: \'blue\',',
+        '    }',
+        '});',
+        'export default class MyComponent extends Component {',
+        '    render() {',
+        '        const trueColor = \'#fff\'; const falseColor = \'#000\' ',
+        '        return <View ',
+        '           style={[style1, ',
+        '                   this.state.isDanger && styles.style1, ',
+        '                   {color: someBoolean ? trueColor : falseColor }]} ',
+        '                />;',
+        '    }',
+        '}',
+      ].join('\n'),
+    },
+  ],
+  invalid: [
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: 0.5}}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Inline style: { backgroundColor: \'#FFFFFF\', opacity: 0.5 }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: this.state.opacity}}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Inline style: { backgroundColor: \'#FFFFFF\' }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={{opacity: this.state.opacity, height: 12}}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Inline style: { height: 12 }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    return <Text style={[styles.text, {backgroundColor: \'#FFFFFF\'}]}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Inline style: { backgroundColor: \'#FFFFFF\' }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
+        '    const someBoolean = false; ',
+        '    return <Text style={[styles.text, someBoolean && {backgroundColor: \'#FFFFFF\'}]}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Inline style: { backgroundColor: \'#FFFFFF\' }',
+      }],
+    },
+    {
+      code: [
+        'const styles = StyleSheet.create({',
+        '    style1: {',
+        '        color: \'red\',',
+        '    },',
+        '    style2: {',
+        '        color: \'blue\',',
+        '    }',
+        '});',
+        'export default class MyComponent extends Component {',
+        '    render() {',
+        '        return <View ',
+        '           style={[style1, ',
+        '                   this.state.isDanger && styles.style1, ',
+        '                   {backgroundColor: someBoolean ? \'#fff\' : \'#000\'}]} ',
+        '                />;',
+        '    }',
+        '}',
+      ].join('\n'),
+      errors: [{
+        message: 'Inline style: { backgroundColor: \'someBoolean ? \\\'#fff\\\' : \\\'#000\\\'\' }', //eslint-disable-line
+      }],
+    },
+  ],
+};
+
+const config = {
+  parser: 'babel-eslint',
+  ecmaFeatures: {
+    classes: true,
+    jsx: true,
+  },
+};
+
+tests.valid.forEach(t => Object.assign(t, config));
+tests.invalid.forEach(t => Object.assign(t, config));
+
+ruleTester.run('no-inline-styles', rule, tests);

--- a/tests/lib/rules/no-inline-styles.js
+++ b/tests/lib/rules/no-inline-styles.js
@@ -113,6 +113,20 @@ const tests = {
       code: [
         'const Hello = React.createClass({',
         '  render: function() {',
+        '    return <Text style={{marginLeft: -7, height: +12}}>',
+        '      Hello {this.props.name}',
+        '     </Text>;',
+        '  }',
+        '});',
+      ].join('\n'),
+      errors: [{
+        message: 'Inline style: { marginLeft: -7, height: 12 }',
+      }],
+    },
+    {
+      code: [
+        'const Hello = React.createClass({',
+        '  render: function() {',
         '    return <Text style={[styles.text, {backgroundColor: \'#FFFFFF\'}]}>',
         '      Hello {this.props.name}',
         '     </Text>;',


### PR DESCRIPTION
I added two new rules suggested in Issue #23 - `no-inline-styles` checks for style objects with literal values inside JSX style attributes, and `no-color-literals` checks for literal values for properties containing the word `color` in them, both in `StyleSheet` objects and JSX style attributes.

I tried to keep the code style similar to the existing rules, but I think there's probably some refactoring/improving that can be done. They're not perfect but they do work, so I figured I'll send them over for review and if you can let me know what you think.

Thanks!