### PR TITLE
Handle unrecognized eslint nodes in style rules helper

### DIFF
--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -335,6 +335,9 @@ const astHelpers = {
     let invalid = false;
     if (node.properties && node.properties.length) {
       node.properties.forEach(p => {
+        if (!p.value || !p.key) {
+          return;
+        }
         if (p.value.type === 'Literal') {
           invalid = true;
           obj[p.key.name] = p.value.value;
@@ -361,7 +364,7 @@ const astHelpers = {
     let invalid = false;
     if (node.properties && node.properties.length) {
       node.properties.forEach(p => {
-        if (p.key.name && p.key.name.toLowerCase().indexOf('color') !== -1) {
+        if (p.key && p.key.name && p.key.name.toLowerCase().indexOf('color') !== -1) {
           if (p.value.type === 'Literal') {
             invalid = true;
             obj[p.key.name] = p.value.value;


### PR DESCRIPTION
E.g. `ExperimentalSpreadProperty` nodes.
Fixes #41 again.