### PR TITLE
Don't crash when `node` is null

### DIFF
--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -183,6 +183,10 @@ const astHelpers = {
   },
 
   collectColorLiterals: function (node, context) {
+    if (!node) {
+      return [];
+    }
+
     currentContent = context;
     if (astHelpers.hasArrayOfStyleReferences(node)) {
       const styleReferenceContainers = node
@@ -308,7 +312,7 @@ const astHelpers = {
   },
 
   hasArrayOfStyleReferences: function (node) {
-    return Boolean(
+    return node && Boolean(
       node.type === 'JSXExpressionContainer' &&
       node.expression &&
       node.expression.type === 'ArrayExpression'


### PR DESCRIPTION
This may happen when using spread operators in stylesheets, as in the example below. I haven't looked into it too deeply -- feel free to improve this PR if you want, but I just wanted it to stop crashing so I could lint 😉 

My code that led to this crash:

```js
const style = StyleSheet.create({
  ...genericStyle,
  ...strippedBaseStyle,
});
```