### PR TITLE
Export shared "all" config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,21 @@ Finally, enable all of the rules that you would like to use.
 
 [status-url]: https://github.com/Intellicode/eslint-plugin-react-native/pulse
 [status-image]: http://img.shields.io/badge/status-maintained-brightgreen.svg?style=flat-square
+
+# Shareable configurations
+
+## All
+
+This plugin also exports an `all` configuration that includes every available rule.
+
+```js
+{
+  "plugins": [
+    /* ... */
+    "react-native"
+  ],
+  "extends": [/* ... */, "plugin:react-native/all"]
+}
+```
+
+**Note**: These configurations will import `eslint-plugin-react-native` and enable JSX in [parser options](http://eslint.org/docs/user-guide/configuring#specifying-parser-options).

--- a/index.js
+++ b/index.js
@@ -1,17 +1,46 @@
 /* eslint-disable global-require */
 'use strict'
 
+var allRules = {
+  'no-unused-styles': require('./lib/rules/no-unused-styles'),
+  'no-inline-styles': require('./lib/rules/no-inline-styles'),
+  'no-color-literals': require('./lib/rules/no-color-literals'),
+  'split-platform-components': require('./lib/rules/split-platform-components'),
+};
+
+function configureAsError(rules) {
+  var result = {};
+  for (var key in rules) {
+    if (!rules.hasOwnProperty(key)) {
+      continue;
+    }
+    result['react-native/' + key] = 2;
+  }
+  return result;
+}
+
+var allRulesConfig = configureAsError(allRules);
+
 module.exports = {
-  rules: {
-    'no-unused-styles': require('./lib/rules/no-unused-styles'),
-    'no-inline-styles': require('./lib/rules/no-inline-styles'),
-    'no-color-literals': require('./lib/rules/no-color-literals'),
-    'split-platform-components': require('./lib/rules/split-platform-components')
-  },
+  deprecatedRules: {},
+  rules: allRules,
   rulesConfig: {
     'no-unused-styles': 0,
     'no-inline-styles': 0,
     'no-color-literals': 0,
     'split-platform-components': 0
+  },
+  configs: {
+    all: {
+      plugin: [
+        'react-native',
+      ],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      rules: allRulesConfig,
+    },
   }
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -42,3 +42,18 @@ describe('all rule files should be exported by the plugin', () => {
     }
   });
 });
+
+describe('configurations', () => {
+  it('should export a \'all\' configuration', () => {
+    assert(plugin.configs.all);
+    Object.keys(plugin.configs.all.rules).forEach((configName) => {
+      assert.equal(configName.indexOf('react-native/'), 0);
+      assert.equal(plugin.configs.all.rules[configName], 2);
+    });
+    rules.forEach((ruleName) => {
+      const inDeprecatedRules = Boolean(plugin.deprecatedRules[ruleName]);
+      const inAllConfig = Boolean(plugin.configs.all.rules['react-native/' + ruleName]);
+      assert(inDeprecatedRules ^ inAllConfig);
+    });
+  });
+});


### PR DESCRIPTION
Hey,

this PR adds a new shared config "all", which can be used to extend from with "plugin:react-native/all".

Closes #17
Shamelessly taken and modified from the eslint-plugin-react codebase :)

Cheers!