### PR TITLE
`eslint` and `babel-eslint` should be listed in `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,18 +22,19 @@
   },
   "homepage": "https://github.com/intellicode/eslint-plugin-react-native",
   "bugs": "https://github.com/intellicode/eslint-plugin-react-native/issues",
-  "dependencies": {
-    "eslint": "3.12.1",
-    "babel-eslint": "7.1.1"
-  },
   "devDependencies": {
+    "babel-eslint": "7.1.1",
     "coveralls": "2.11.15",
+    "eslint": "3.12.1",
     "eslint-config-airbnb": "13.0.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-jsx-a11y": "2.2.2",
     "eslint-plugin-react": "6.8.0",
     "istanbul": "0.4.4",
     "mocha": "3.2.0"
+  },
+  "peerDependencies": {
+    "eslint": "3.12.1"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
[Referring to yarn doc](https://yarnpkg.com/en/docs/dependency-types#toc-dependencies):

> ## `dependencies`
> These are your normal dependencies, or rather ones that you need when running your code (e.g. React or ImmutableJS).

And I think `dependencies` in this repo (`eslint` and `babel-eslint`) should be listed in `devDependencies`.

Why [in this commit](https://github.com/Intellicode/eslint-plugin-react-native/commit/c3d99e47a5475b2eb3c331234fc6020a7cf58f9e?diff=split#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) did you move them to `dependencies`?