### PR TITLE
#129 fix

### DIFF
--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -18,7 +18,7 @@ module.exports = Components.detect((context, components) => {
   function reportUnusedStyles(unusedStyles) {
     Object.keys(unusedStyles).forEach((key) => {
       if ({}.hasOwnProperty.call(unusedStyles, key)) {
-        const styles = unusedStyles[key];
+        const styles = unusedStyles[key].filter(({ type }) => type === 'Property');
         styles.forEach((node) => {
           const message = [
             'Unused style detected: ',


### PR DESCRIPTION
this PR fixes https://github.com/Intellicode/eslint-plugin-react-native/issues/129 . I believe, that only possible node.type we should check is `Property`.