### PR TITLE
fix(no-unused-styles): allow use of spread operator

### DIFF
--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -140,7 +140,8 @@ const astHelpers = {
       return node
         .init
         .arguments[0]
-        .properties;
+        .properties
+        .filter(property => property.type === 'Property');
     }
 
     return [];

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -247,6 +247,25 @@ ruleTester.run('no-unused-styles', rule, {
       classes: true,
       jsx: true,
     },
+  }, {
+    code: [
+      'const additionalStyles = {};',
+      'const styles = StyleSheet.create({',
+      '  name: {},',
+      '  ...additionalStyles',
+      '});',
+      'const Hello = React.createClass({',
+      '  render: function() {',
+      '    return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;',
+      '  }',
+      '});',
+    ].join('\n'),
+    parser: 'babel-eslint',
+    ecmaFeatures: {
+      classes: true,
+      jsx: true,
+      spread: true,
+    },
   }],
 
   invalid: [{


### PR DESCRIPTION
https://github.com/Intellicode/eslint-plugin-react-native/pull/141 was not working for me. This PR also includes a test case to make sure the issue is fixed.

____

The linter crashes with an error when the spread operator
was used in a stylesheet object. This fix will ignore all
styles that are not of type Property.

Fix #129