### PR TITLE
split-platform-components works on '.test' files also

### DIFF
--- a/lib/rules/split-platform-components.js
+++ b/lib/rules/split-platform-components.js
@@ -37,11 +37,11 @@ module.exports = function (context) {
     components.forEach((node) => {
       const propName = getName(node);
 
-      if (propName.includes('IOS') && !filename.endsWith('.ios.js')) {
+      if (propName.includes('IOS') && !filename.match(/\.ios(\.test)?\.js$/)) {
         context.report(node, containsAndroidAndIOS ? conflictMessage : iosMessage);
       }
 
-      if (propName.includes('Android') && !filename.endsWith('.android.js')) {
+      if (propName.includes('Android') && !filename.match(/\.android(\.test)?\.js$/)) {
         context.report(node, containsAndroidAndIOS ? conflictMessage : androidMessage);
       }
     });

--- a/lib/rules/split-platform-components.js
+++ b/lib/rules/split-platform-components.js
@@ -11,6 +11,12 @@ module.exports = function (context) {
   const androidMessage = 'Android components should be placed in android files';
   const iosMessage = 'IOS components should be placed in ios files';
   const conflictMessage = 'IOS and Android components can\'t be mixed';
+  const iosPathRegex = context.options[0] && context.options[0].iosPathRegex
+    ? new RegExp(context.options[0].iosPathRegex)
+    : /\.ios\.js$/;
+  const androidPathRegex = context.options[0] && context.options[0].androidPathRegex
+    ? new RegExp(context.options[0].androidPathRegex)
+    : /\.android\.js$/;
 
   function getName(node) {
     if (node.type === 'Property') {
@@ -37,11 +43,11 @@ module.exports = function (context) {
     components.forEach((node) => {
       const propName = getName(node);
 
-      if (propName.includes('IOS') && !filename.match(/\.ios(\.test)?\.js$/)) {
+      if (propName.includes('IOS') && !filename.match(iosPathRegex)) {
         context.report(node, containsAndroidAndIOS ? conflictMessage : iosMessage);
       }
 
-      if (propName.includes('Android') && !filename.match(/\.android(\.test)?\.js$/)) {
+      if (propName.includes('Android') && !filename.match(androidPathRegex)) {
         context.report(node, containsAndroidAndIOS ? conflictMessage : androidMessage);
       }
     });
@@ -71,4 +77,15 @@ module.exports = function (context) {
   };
 };
 
-module.exports.schema = [];
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    androidPathRegex: {
+      type: 'string',
+    },
+    iosPathRegex: {
+      type: 'string',
+    },
+  },
+  additionalProperties: false,
+}];

--- a/tests/lib/rules/split-platform-components.js
+++ b/tests/lib/rules/split-platform-components.js
@@ -112,6 +112,42 @@ ruleTester.run('split-platform-components', rule, {
       classes: true,
       jsx: true,
     },
+  }, {
+    code: [
+      'const React = require(\'react-native\');',
+      'const {',
+      '  ActivityIndicatiorIOS,',
+      '} = React',
+      'const Hello = React.createClass({',
+      '  render: function() {',
+      '    return <ActivityIndicatiorIOS />;',
+      '  }',
+      '});',
+    ].join('\n'),
+    filename: 'Hello.ios.test.js',
+    parser: 'babel-eslint',
+    ecmaFeatures: {
+      classes: true,
+      jsx: true,
+    },
+  }, {
+    code: [
+      'const React = require(\'react-native\');',
+      'const {',
+      '  ProgressBarAndroid,',
+      '} = React',
+      'const Hello = React.createClass({',
+      '  render: function() {',
+      '    return <ProgressBarAndroid />;',
+      '  }',
+      '});',
+    ].join('\n'),
+    parser: 'babel-eslint',
+    filename: 'Hello.android.test.js',
+    ecmaFeatures: {
+      classes: true,
+      jsx: true,
+    },
   }],
 
   invalid: [{

--- a/tests/lib/rules/split-platform-components.js
+++ b/tests/lib/rules/split-platform-components.js
@@ -124,6 +124,9 @@ ruleTester.run('split-platform-components', rule, {
       '  }',
       '});',
     ].join('\n'),
+    options: [{
+      iosPathRegex: '\\.ios(\\.test)?\\.js$',
+    }],
     filename: 'Hello.ios.test.js',
     parser: 'babel-eslint',
     ecmaFeatures: {
@@ -143,6 +146,9 @@ ruleTester.run('split-platform-components', rule, {
       '});',
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{
+      androidPathRegex: '\\.android(\\.test)?\\.js$',
+    }],
     filename: 'Hello.android.test.js',
     ecmaFeatures: {
       classes: true,


### PR DESCRIPTION
This stops the split-platform-components from complaining when you import a platform specific component in a platform specific test file: `.ios.test.js`.