### PR TITLE
Add eslint 4 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mocha": "3.4.1"
   },
   "peerDependencies": {
-    "eslint": "^3.17.0"
+    "eslint": "^3.17.0 || ^4.0.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
This updates the peer dependencies to accept either eslint version 3 or 4, to remove warning on install.

eslint-plugin-react does this as shown here:
https://github.com/yannickcr/eslint-plugin-react/blob/master/package.json#L38