### PR TITLE
Refactor tests to use template literals instead of .join() syntax

### DIFF
--- a/tests/lib/rules/no-color-literals.js
+++ b/tests/lib/rules/no-color-literals.js
@@ -150,6 +150,7 @@ const tests = {
                 color: 'red',
             },
             style2: {
+                // this is illegal even though it's not used anywhere
                 borderBottomColor: 'blue',
             }
         });

--- a/tests/lib/rules/no-color-literals.js
+++ b/tests/lib/rules/no-color-literals.js
@@ -149,8 +149,8 @@ const tests = {
             style1: {
                 color: 'red',
             },
+            // this is illegal even though it's not used anywhere
             style2: {
-                // this is illegal even though it's not used anywhere
                 borderBottomColor: 'blue',
             }
         });

--- a/tests/lib/rules/no-color-literals.js
+++ b/tests/lib/rules/no-color-literals.js
@@ -23,147 +23,146 @@ const ruleTester = new RuleTester();
 const tests = {
   valid: [
     {
-      code: [
-        'const $red = \'red\'',
-        'const $blue = \'blue\'',
-        'const styles = StyleSheet.create({',
-        '    style1: {',
-        '        color: $red,',
-        '    },',
-        '    style2: {',
-        '        color: $blue,',
-        '    }',
-        '});',
-        'export default class MyComponent extends Component {',
-        '    render() {',
-        '        const isDanger = true;',
-        '        return <View ',
-        '                   style={[styles.style1, isDanger ? styles.style1 : styles.style2]}',
-        '               />;',
-        '    }',
-        '}',
-      ].join('\n'),
+      code: `
+        const $red = 'red'
+        const $blue = 'blue'
+        const styles = StyleSheet.create({
+            style1: {
+                color: $red,
+            },
+            style2: {
+                color: $blue,
+            }
+        });
+        export default class MyComponent extends Component {
+            render() {
+                const isDanger = true;
+                return <View 
+                           style={[styles.style1, isDanger ? styles.style1 : styles.style2]}
+                       />;
+            }
+        }
+      `,
     },
     {
-      code: [
-        'const styles = StyleSheet.create({',
-        '    style1: {',
-        '        color: $red,',
-        '    },',
-        '    style2: {',
-        '        color: $blue,',
-        '    }',
-        '});',
-        'export default class MyComponent extends Component {',
-        '    render() {',
-        '        const trueColor = \'#fff\';',
-        '        const falseColor = \'#000\' ',
-        '        return <View ',
-        '           style={[style1, ',
-        '                   this.state.isDanger && {color: falseColor}, ',
-        '                   {color: someBoolean ? trueColor : falseColor }]} ',
-        '                />;',
-        '    }',
-        '}',
-      ].join('\n'),
+      code: `
+        const styles = StyleSheet.create({
+            style1: {
+                color: $red,
+            },
+            style2: {
+                color: $blue,
+            }
+        });
+        export default class MyComponent extends Component {
+            render() {
+                const trueColor = '#fff';
+                const falseColor = '#000' 
+                return <View 
+                   style={[style1, 
+                           this.state.isDanger && {color: falseColor}, 
+                           {color: someBoolean ? trueColor : falseColor }]} 
+                        />;
+            }
+        }
+      `,
     },
   ],
   invalid: [
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: 0.5}}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={{backgroundColor: '#FFFFFF', opacity: 0.5}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: this.state.opacity}}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={{backgroundColor: '#FFFFFF', opacity: this.state.opacity}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
       }],
     },
     {
-      code: [
-        'const styles = StyleSheet.create({',
-        '  text: {fontColor: \'#000\'}',
-        '})',
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={{opacity: this.state.opacity, height: 12, fontColor: styles.text}}>', //eslint-disable-line
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const styles = StyleSheet.create({
+          text: {fontColor: '#000'}
+        })
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={{opacity: this.state.opacity, height: 12, fontColor: styles.text}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Color literal: { fontColor: \'#000\' }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={[styles.text, {backgroundColor: \'#FFFFFF\'}]}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={[styles.text, {backgroundColor: '#FFFFFF'}]}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    const someBoolean = false; ',
-        '    return <Text style={[styles.text, someBoolean && {backgroundColor: \'#FFFFFF\'}]}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            const someBoolean = false; 
+            return <Text style={[styles.text, someBoolean && {backgroundColor: '#FFFFFF'}]}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
       }],
     },
     {
-      code: [
-        'const styles = StyleSheet.create({',
-        '    style1: {',
-        '        color: \'red\',',
-        '    },',
-        // this is illegal even though it's not used anywhere
-        '    style2: {',
-        '        borderBottomColor: \'blue\',',
-        '    }',
-        '});',
-        'export default class MyComponent extends Component {',
-        '    render() {',
-        '        return <View ',
-        '           style={[style1, ',
-        '                   this.state.isDanger && styles.style1, ',
-        '                   {backgroundColor: someBoolean ? \'#fff\' : \'#000\'}]} ',
-        '                />;',
-        '    }',
-        '}',
-      ].join('\n'),
+      code: `
+        const styles = StyleSheet.create({
+            style1: {
+                color: 'red',
+            },
+            style2: {
+                borderBottomColor: 'blue',
+            }
+        });
+        export default class MyComponent extends Component {
+            render() {
+                return <View 
+                   style={[style1, 
+                           this.state.isDanger && styles.style1, 
+                           {backgroundColor: someBoolean ? '#fff' : '#000'}]} 
+                        />;
+            }
+        }
+      `,
       errors: [
         {
           message: 'Color literal: { color: \'red\' }',

--- a/tests/lib/rules/no-inline-styles.js
+++ b/tests/lib/rules/no-inline-styles.js
@@ -25,154 +25,154 @@ const tests = {
 
   valid: [
     {
-      code: [
-        'const styles = StyleSheet.create({',
-        '    style1: {',
-        '        color: \'red\',',
-        '    },',
-        '    style2: {',
-        '        color: \'blue\',',
-        '    }',
-        '});',
-        'export default class MyComponent extends Component {',
-        '    static propTypes = {',
-        '        isDanger: PropTypes.bool',
-        '    };',
-        '    render() {',
-        '        return <View style={this.props.isDanger ? styles.style1 : styles.style2} />;',
-        '    }',
-        '}',
-      ].join('\n'),
+      code: `
+        const styles = StyleSheet.create({
+            style1: {
+                color: 'red',
+            },
+            style2: {
+                color: 'blue',
+            }
+        });
+        export default class MyComponent extends Component {
+            static propTypes = {
+                isDanger: PropTypes.bool
+            };
+            render() {
+                return <View style={this.props.isDanger ? styles.style1 : styles.style2} />;
+            }
+        }
+      `,
     },
     {
-      code: [
-        'const styles = StyleSheet.create({',
-        '    style1: {',
-        '        color: \'red\',',
-        '    },',
-        '    style2: {',
-        '        color: \'blue\',',
-        '    }',
-        '});',
-        'export default class MyComponent extends Component {',
-        '    render() {',
-        '        const trueColor = \'#fff\'; const falseColor = \'#000\' ',
-        '        return <View ',
-        '           style={[style1, ',
-        '                   this.state.isDanger && styles.style1, ',
-        '                   {color: someBoolean ? trueColor : falseColor }]} ',
-        '                />;',
-        '    }',
-        '}',
-      ].join('\n'),
+      code: `
+        const styles = StyleSheet.create({
+            style1: {
+                color: 'red',
+            },
+            style2: {
+                color: 'blue',
+            }
+        });
+        export default class MyComponent extends Component {
+            render() {
+                const trueColor = '#fff'; const falseColor = '#000' 
+                return <View 
+                   style={[style1, 
+                           this.state.isDanger && styles.style1, 
+                           {color: someBoolean ? trueColor : falseColor }]} 
+                        />;
+            }
+        }
+      `,
     },
   ],
   invalid: [
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: 0.5}}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={{backgroundColor: '#FFFFFF', opacity: 0.5}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Inline style: { backgroundColor: \'#FFFFFF\', opacity: 0.5 }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={{backgroundColor: \'#FFFFFF\', opacity: this.state.opacity}}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={{backgroundColor: '#FFFFFF', opacity: this.state.opacity}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Inline style: { backgroundColor: \'#FFFFFF\' }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={{opacity: this.state.opacity, height: 12}}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={{opacity: this.state.opacity, height: 12}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Inline style: { height: 12 }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={{marginLeft: -7, height: +12}}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={{marginLeft: -7, height: +12}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Inline style: { marginLeft: -7, height: 12 }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    return <Text style={[styles.text, {backgroundColor: \'#FFFFFF\'}]}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            return <Text style={[styles.text, {backgroundColor: '#FFFFFF'}]}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Inline style: { backgroundColor: \'#FFFFFF\' }',
       }],
     },
     {
-      code: [
-        'const Hello = React.createClass({',
-        '  render: function() {',
-        '    const someBoolean = false; ',
-        '    return <Text style={[styles.text, someBoolean && {backgroundColor: \'#FFFFFF\'}]}>',
-        '      Hello {this.props.name}',
-        '     </Text>;',
-        '  }',
-        '});',
-      ].join('\n'),
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            const someBoolean = false; 
+            return <Text style={[styles.text, someBoolean && {backgroundColor: '#FFFFFF'}]}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
       errors: [{
         message: 'Inline style: { backgroundColor: \'#FFFFFF\' }',
       }],
     },
     {
-      code: [
-        'const styles = StyleSheet.create({',
-        '    style1: {',
-        '        color: \'red\',',
-        '    },',
-        '    style2: {',
-        '        color: \'blue\',',
-        '    }',
-        '});',
-        'export default class MyComponent extends Component {',
-        '    render() {',
-        '        return <View ',
-        '           style={[style1, ',
-        '                   this.state.isDanger && styles.style1, ',
-        '                   {backgroundColor: someBoolean ? \'#fff\' : \'#000\'}]} ',
-        '                />;',
-        '    }',
-        '}',
-      ].join('\n'),
+      code: `
+        const styles = StyleSheet.create({
+            style1: {
+                color: 'red',
+            },
+            style2: {
+                color: 'blue',
+            }
+        });
+        export default class MyComponent extends Component {
+            render() {
+                return <View 
+                   style={[style1, 
+                           this.state.isDanger && styles.style1, 
+                           {backgroundColor: someBoolean ? '#fff' : '#000'}]} 
+                        />;
+            }
+        }
+      `,
       errors: [{
         message: 'Inline style: { backgroundColor: \'someBoolean ? \\\'#fff\\\' : \\\'#000\\\'\' }', //eslint-disable-line
       }],

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -21,232 +21,232 @@ require('babel-eslint');
 const ruleTester = new RuleTester();
 const tests = {
   valid: [{
-    code: [
-      'const styles = StyleSheet.create({',
-      '  name: {}',
-      '});',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        name: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
   }, {
-    code: [
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;',
-      '  }',
-      '});',
-      'const styles = StyleSheet.create({',
-      '  name: {}',
-      '});',
-    ].join('\n'),
+    code: `
+      const Hello = React.createClass({
+        render: function() {
+          return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+      const styles = StyleSheet.create({
+        name: {}
+      });
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  name: {}',
-      '});',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <Text style={styles.name}>Hello {this.props.name}</Text>;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        name: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          return <Text style={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  name: {},',
-      '  welcome: {}',
-      '});',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <Text style={styles.name}>Hello {this.props.name}</Text>;',
-      '  }',
-      '});',
-      'const Welcome = React.createClass({',
-      '  render: function() {',
-      '    return <Text style={styles.welcome}>Welcome</Text>;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        name: {},
+        welcome: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          return <Text style={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+      const Welcome = React.createClass({
+        render: function() {
+          return <Text style={styles.welcome}>Welcome</Text>;
+        }
+      });
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  text: {}',
-      '})',
-      'const Hello = React.createClass({',
-      '  propTypes: {',
-      '    textStyle: Text.propTypes.style,',
-      '  },',
-      '  render: function() {',
-      '    return <Text style={[styles.text, textStyle]}>Hello {this.props.name}</Text>;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const Hello = React.createClass({
+        propTypes: {
+          textStyle: Text.propTypes.style,
+        },
+        render: function() {
+          return <Text style={[styles.text, textStyle]}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  text: {}',
-      '})',
-      'const styles2 = StyleSheet.create({',
-      '  text: {}',
-      '})',
-      'const Hello = React.createClass({',
-      '  propTypes: {',
-      '    textStyle: Text.propTypes.style,',
-      '  },',
-      '  render: function() {',
-      '    return (',
-      '      <Text style={[styles.text, styles2.text, textStyle]}>',
-      '       Hello {this.props.name}',
-      '      </Text>',
-      '     );',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const styles2 = StyleSheet.create({
+        text: {}
+      })
+      const Hello = React.createClass({
+        propTypes: {
+          textStyle: Text.propTypes.style,
+        },
+        render: function() {
+          return (
+            <Text style={[styles.text, styles2.text, textStyle]}>
+             Hello {this.props.name}
+            </Text>
+           );
+        }
+      });
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  text: {}',
-      '});',
-      'const Hello = React.createClass({',
-      '  getInitialState: function() {',
-      '    return { condition: true, condition2: true }; ',
-      '  },',
-      '  render: function() {',
-      '    return (',
-      '      <Text',
-      '        style={[',
-      '          this.state.condition &&',
-      '          this.state.condition2 &&',
-      '          styles.text]}>',
-      '        Hello {this.props.name}',
-      '      </Text>',
-      '    );',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        text: {}
+      });
+      const Hello = React.createClass({
+        getInitialState: function() {
+          return { condition: true, condition2: true }; 
+        },
+        render: function() {
+          return (
+            <Text
+              style={[
+                this.state.condition &&
+                this.state.condition2 &&
+                styles.text]}>
+              Hello {this.props.name}
+            </Text>
+          );
+        }
+      });
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  text: {},',
-      '  text2: {},',
-      '});',
-      'const Hello = React.createClass({',
-      '  getInitialState: function() {',
-      '    return { condition: true }; ',
-      '  },',
-      '  render: function() {',
-      '    return (',
-      '      <Text style={[this.state.condition ? styles.text : styles.text2]}>',
-      '        Hello {this.props.name}',
-      '      </Text>',
-      '    );',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        text: {},
+        text2: {},
+      });
+      const Hello = React.createClass({
+        getInitialState: function() {
+          return { condition: true }; 
+        },
+        render: function() {
+          return (
+            <Text style={[this.state.condition ? styles.text : styles.text2]}>
+              Hello {this.props.name}
+            </Text>
+          );
+        }
+      });
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '    style1: {',
-      '        color: \'red\',',
-      '    },',
-      '    style2: {',
-      '        color: \'blue\',',
-      '    }',
-      '});',
-      'export default class MyComponent extends Component {',
-      '    static propTypes = {',
-      '        isDanger: PropTypes.bool',
-      '    };',
-      '    render() {',
-      '        return <View style={this.props.isDanger ? styles.style1 : styles.style2} />;',
-      '    }',
-      '}',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+          style1: {
+              color: 'red',
+          },
+          style2: {
+              color: 'blue',
+          }
+      });
+      export default class MyComponent extends Component {
+          static propTypes = {
+              isDanger: PropTypes.bool
+          };
+          render() {
+              return <View style={this.props.isDanger ? styles.style1 : styles.style2} />;
+          }
+      }
+    `,
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  text: {}',
-      '})',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+    `,
   }, {
-    code: [
-      'const Hello = React.createClass({',
-      '  getInitialState: function() {',
-      '    return { condition: true }; ',
-      '  },',
-      '  render: function() {',
-      '    const myStyle = this.state.condition ? styles.text : styles.text2;',
-      '    return (',
-      '        <Text style={myStyle}>',
-      '            Hello {this.props.name}',
-      '        </Text>',
-      '    );',
-      '  }',
-      '});',
-      'const styles = StyleSheet.create({',
-      '  text: {},',
-      '  text2: {},',
-      '});',
-    ].join('\n'),
+    code: `
+      const Hello = React.createClass({
+        getInitialState: function() {
+          return { condition: true }; 
+        },
+        render: function() {
+          const myStyle = this.state.condition ? styles.text : styles.text2;
+          return (
+              <Text style={myStyle}>
+                  Hello {this.props.name}
+              </Text>
+          );
+        }
+      });
+      const styles = StyleSheet.create({
+        text: {},
+        text2: {},
+      });
+    `,
   }, {
-    code: [
-      'const additionalStyles = {};',
-      'const styles = StyleSheet.create({',
-      '  name: {},',
-      '  ...additionalStyles',
-      '});',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const additionalStyles = {};
+      const styles = StyleSheet.create({
+        name: {},
+        ...additionalStyles
+      });
+      const Hello = React.createClass({
+        render: function() {
+          return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
   }],
 
   invalid: [{
-    code: [
-      'const styles = StyleSheet.create({',
-      '  text: {}',
-      '})',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <Text style={styles.b}>Hello {this.props.name}</Text>;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const Hello = React.createClass({
+        render: function() {
+          return <Text style={styles.b}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
     errors: [{
       message: 'Unused style detected: styles.text',
     }],
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  foo: {},',
-      '  bar: {},',
-      '})',
-      'class Foo extends React.Component {',
-      '  render() {',
-      '    return <View style={styles.foo}/>;',
-      '  }',
-      '}',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        foo: {},
+        bar: {},
+      })
+      class Foo extends React.Component {
+        render() {
+          return <View style={styles.foo}/>;
+        }
+      }
+    `,
     errors: [{
       message: 'Unused style detected: styles.bar',
     }],
   }, {
-    code: [
-      'const styles = StyleSheet.create({',
-      '  foo: {},',
-      '  bar: {},',
-      '})',
-      'class Foo extends React.PureComponent {',
-      '  render() {',
-      '    return <View style={styles.foo}/>;',
-      '  }',
-      '}',
-    ].join('\n'),
+    code: `
+      const styles = StyleSheet.create({
+        foo: {},
+        bar: {},
+      })
+      class Foo extends React.PureComponent {
+        render() {
+          return <View style={styles.foo}/>;
+        }
+      }
+    `,
     errors: [{
       message: 'Unused style detected: styles.bar',
     }],

--- a/tests/lib/rules/split-platform-components.js
+++ b/tests/lib/rules/split-platform-components.js
@@ -22,93 +22,93 @@ require('babel-eslint');
 const ruleTester = new RuleTester();
 const tests = {
   valid: [{
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  ActivityIndicatiorIOS,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <ActivityIndicatiorIOS />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        ActivityIndicatiorIOS,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <ActivityIndicatiorIOS />;
+        }
+      });
+    `,
     filename: 'Hello.ios.js',
   }, {
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  ProgressBarAndroid,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <ProgressBarAndroid />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        ProgressBarAndroid,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <ProgressBarAndroid />;
+        }
+      });
+    `,
     filename: 'Hello.android.js',
   }, {
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  View,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <View />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        View,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <View />;
+        }
+      });
+    `,
     filename: 'Hello.js',
   }, {
-    code: [
-      'import {',
-      '  ActivityIndicatiorIOS,',
-      '} from \'react-native\'',
-    ].join('\n'),
+    code: `
+      import {
+        ActivityIndicatiorIOS,
+      } from 'react-native'
+    `,
     filename: 'Hello.ios.js',
   }, {
-    code: [
-      'import {',
-      '  ProgressBarAndroid,',
-      '} from \'react-native\'',
-    ].join('\n'),
+    code: `
+      import {
+        ProgressBarAndroid,
+      } from 'react-native'
+    `,
     filename: 'Hello.android.js',
   }, {
-    code: [
-      'import {',
-      '  View,',
-      '} from \'react-native\'',
-    ].join('\n'),
+    code: `
+      import {
+        View,
+      } from 'react-native'
+    `,
     filename: 'Hello.js',
   }, {
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  ActivityIndicatiorIOS,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <ActivityIndicatiorIOS />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        ActivityIndicatiorIOS,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <ActivityIndicatiorIOS />;
+        }
+      });
+    `,
     options: [{
       iosPathRegex: '\\.ios(\\.test)?\\.js$',
     }],
     filename: 'Hello.ios.test.js',
   }, {
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  ProgressBarAndroid,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <ProgressBarAndroid />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        ProgressBarAndroid,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <ProgressBarAndroid />;
+        }
+      });
+    `,
     options: [{
       androidPathRegex: '\\.android(\\.test)?\\.js$',
     }],
@@ -116,50 +116,50 @@ const tests = {
   }],
 
   invalid: [{
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  ProgressBarAndroid,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <ProgressBarAndroid />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        ProgressBarAndroid,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <ProgressBarAndroid />;
+        }
+      });
+    `,
     filename: 'Hello.js',
     errors: [{
       message: 'Android components should be placed in android files',
     }],
   }, {
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  ActivityIndicatiorIOS,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <ActivityIndicatiorIOS />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        ActivityIndicatiorIOS,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <ActivityIndicatiorIOS />;
+        }
+      });
+    `,
     filename: 'Hello.js',
     errors: [{
       message: 'IOS components should be placed in ios files',
     }],
   }, {
-    code: [
-      'const React = require(\'react-native\');',
-      'const {',
-      '  ActivityIndicatiorIOS,',
-      '  ProgressBarAndroid,',
-      '} = React',
-      'const Hello = React.createClass({',
-      '  render: function() {',
-      '    return <ActivityIndicatiorIOS />;',
-      '  }',
-      '});',
-    ].join('\n'),
+    code: `
+      const React = require('react-native');
+      const {
+        ActivityIndicatiorIOS,
+        ProgressBarAndroid,
+      } = React
+      const Hello = React.createClass({
+        render: function() {
+          return <ActivityIndicatiorIOS />;
+        }
+      });
+    `,
     filename: 'Hello.js',
     errors: [{
       message: 'IOS and Android components can\'t be mixed',
@@ -167,32 +167,32 @@ const tests = {
       message: 'IOS and Android components can\'t be mixed',
     }],
   }, {
-    code: [
-      'import {',
-      '  ProgressBarAndroid,',
-      '} from \'react-native\'',
-    ].join('\n'),
+    code: `
+      import {
+        ProgressBarAndroid,
+      } from 'react-native'
+    `,
     filename: 'Hello.js',
     errors: [{
       message: 'Android components should be placed in android files',
     }],
   }, {
-    code: [
-      'import {',
-      '  ActivityIndicatiorIOS,',
-      '} from \'react-native\'',
-    ].join('\n'),
+    code: `
+      import {
+        ActivityIndicatiorIOS,
+      } from 'react-native'
+    `,
     filename: 'Hello.js',
     errors: [{
       message: 'IOS components should be placed in ios files',
     }],
   }, {
-    code: [
-      'import {',
-      '  ActivityIndicatiorIOS,',
-      '  ProgressBarAndroid,',
-      '} from \'react-native\'',
-    ].join('\n'),
+    code: `
+      import {
+        ActivityIndicatiorIOS,
+        ProgressBarAndroid,
+      } from 'react-native'
+    `,
     filename: 'Hello.js',
     errors: [{
       message: 'IOS and Android components can\'t be mixed',


### PR DESCRIPTION
I recently wrote a small codemod to transform the eslint tests from using the `code: ['','',''].join('\n')` syntax to use the template literal syntax instead.

The code is available at: https://astexplorer.net/#/gist/000b6e8110a245ca6384c260b954e452/1687ee893085fdae7119c809294e5ed43a3fe428

All tests of this project were able to translate quite nicely.  I'm not sure if you want this change but IMHO it makes working with tests much much easier. 😄 

There's 1 comment that I had to re-add, please check if it's in the right location.