### PR TITLE
no-inline-styles false triggers on unary variables

### DIFF
--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -334,10 +334,10 @@ const astHelpers = {
             invalid = true;
             obj[p.key.name] = getSourceCode(innerNode);
           }
-        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '-') {
+        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '-' && p.value.argument.type === 'Literal') {
           invalid = true;
           obj[p.key.name] = -1 * p.value.argument.value;
-        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '+') {
+        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '+' && p.value.argument.type === 'Literal') {
           invalid = true;
           obj[p.key.name] = p.value.argument.value;
         }

--- a/tests/lib/rules/no-inline-styles.js
+++ b/tests/lib/rules/no-inline-styles.js
@@ -66,6 +66,18 @@ const tests = {
         }
       `,
     },
+    {
+      code: `
+        const Hello = React.createClass({
+          render: function() {
+            const exampleVar = 10;
+            return <Text style={{marginLeft: -exampleVar, height: +examplevar}}>
+              Hello {this.props.name}
+             </Text>;
+          }
+        });
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Issue #185 (https://github.com/Intellicode/eslint-plugin-react-native/issues/185) is that when there is an unary expression with a variable (eg `+blah` or `-foo`) in the style it is flagged for the rule. Only styles with literal values should be flagged (eg `-1` or `+5` ), whereas those with any variables should be allowed (per the description in the rule docs)