### PR TITLE
Use "parserOptions" instead of just "ecmaFeatures"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ If it is not already the case you must also configure `ESLint` to support JSX.
 
 ```json
 {
-  "ecmaFeatures": {
-    "jsx": true
+  "parserOptions": {
+      "ecmaFeatures": {
+          "jsx": true
+      }
   }
 }
 ```


### PR DESCRIPTION
The 'ecmaFeatures' config file property is deprecated so we should use "parserOptions" > "ecmaFeatures" instead.