### PR TITLE
Add support for namespaced StyleSheet.create(...) calls.

### DIFF
--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -95,15 +95,30 @@ const getSourceCode = node => currentContent
 const getStyleSheetObjectNames = settings =>
   settings['react-native/style-sheet-object-names'] || ['StyleSheet'];
 
+const getNamespaces = settings =>
+  settings['react-native/react-native-namespaces'] || ['RN'];
+
 const astHelpers = {
-  containsStyleSheetObject: function (node, objectNames) {
+
+  containsStyleSheetObject: function (node, namespaces, objectNames) {
     return Boolean(
       node &&
-      node.init &&
-      node.init.callee &&
-      node.init.callee.object &&
-      node.init.callee.object.name &&
-      objectNames.includes(node.init.callee.object.name)
+        node.init &&
+        node.init.callee &&
+        ((node.init.callee.object &&
+          node.init.callee.object.name &&
+          objectNames.includes(node.init.callee.object.name)) ||
+          (node.init.callee.type &&
+            node.init.callee.type === 'MemberExpression' &&
+            node.init.callee.object &&
+            node.init.callee.object.type &&
+            node.init.callee.object.type === 'MemberExpression' &&
+            node.init.callee.object.object &&
+            node.init.callee.object.object.name &&
+            namespaces.includes(node.init.callee.object.object.name) &&
+            node.init.callee.object.property &&
+            node.init.callee.object.property.name &&
+            objectNames.includes(node.init.callee.object.property.name)))
     );
   },
 
@@ -118,10 +133,12 @@ const astHelpers = {
   },
 
   isStyleSheetDeclaration: function (node, settings) {
+
+    const namespaces = getNamespaces(settings);
     const objectNames = getStyleSheetObjectNames(settings);
 
     return Boolean(
-      astHelpers.containsStyleSheetObject(node, objectNames) &&
+      astHelpers.containsStyleSheetObject(node, namespaces, objectNames) &&
       astHelpers.containsCreateCall(node)
     );
   },


### PR DESCRIPTION
Sometimes the imports are namespaced:
```
import RN from 'react-native';
```

This merge allows use of ```RN.StyleSheet.create({...})``` and possibility to declare these namespaces via ```react-native/react-native-namespaces``` setting.
