### PR TITLE
Find StyleSheet declarations that are not variables

### DIFF
--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -31,7 +31,7 @@ module.exports = Components.detect((context) => {
   }
 
   return {
-    VariableDeclarator: (node) => {
+    CallExpression: (node) => {
       if (astHelpers.isStyleSheetDeclaration(node, context.settings)) {
         const styles = astHelpers.getStyleDeclarations(node);
 

--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -41,7 +41,7 @@ module.exports = Components.detect((context, components) => {
       }
     },
 
-    VariableDeclarator: function (node) {
+    CallExpression: function (node) {
       if (astHelpers.isStyleSheetDeclaration(node, context.settings)) {
         const styleSheetName = astHelpers.getStyleSheetName(node);
         const styles = astHelpers.getStyleDeclarations(node);

--- a/lib/rules/sort-styles.js
+++ b/lib/rules/sort-styles.js
@@ -107,7 +107,7 @@ module.exports = (context) => {
   }
 
   return {
-    VariableDeclarator: function (node) {
+    CallExpression: function (node) {
       if (!isStyleSheetDeclaration(node, context.settings)) {
         return;
       }

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -99,21 +99,20 @@ const astHelpers = {
   containsStyleSheetObject: function (node, objectNames) {
     return Boolean(
       node &&
-      node.init &&
-      node.init.callee &&
-      node.init.callee.object &&
-      node.init.callee.object.name &&
-      objectNames.includes(node.init.callee.object.name)
+      node.type === 'CallExpression' &&
+      node.callee &&
+      node.callee.object &&
+      node.callee.object.name &&
+      objectNames.includes(node.callee.object.name)
     );
   },
 
   containsCreateCall: function (node) {
     return Boolean(
       node &&
-      node.init &&
-      node.init.callee &&
-      node.init.callee.property &&
-      node.init.callee.property.name === 'create'
+      node.callee &&
+      node.callee.property &&
+      node.callee.property.name === 'create'
     );
   },
 
@@ -127,20 +126,20 @@ const astHelpers = {
   },
 
   getStyleSheetName: function (node) {
-    if (node && node.id) {
-      return node.id.name;
+    if (node && node.parent && node.parent.id) {
+      return node.parent.id.name;
     }
   },
 
   getStyleDeclarations: function (node) {
     if (
       node &&
-      node.init &&
-      node.init.arguments &&
-      node.init.arguments[0] &&
-      node.init.arguments[0].properties
+      node.type === 'CallExpression' &&
+      node.arguments &&
+      node.arguments[0] &&
+      node.arguments[0].properties
     ) {
-      return node.init.arguments[0].properties.filter(property => property.type === 'Property');
+      return node.arguments[0].properties.filter(property => property.type === 'Property');
     }
 
     return [];
@@ -149,12 +148,13 @@ const astHelpers = {
   getStyleDeclarationsChunks: function (node) {
     if (
       node &&
-      node.init &&
-      node.init.arguments &&
-      node.init.arguments[0] &&
-      node.init.arguments[0].properties
+      node.type === 'CallExpression' &&
+      node.arguments &&
+      node.arguments[0] &&
+      node.arguments[0].properties
     ) {
-      const properties = node.init.arguments[0].properties;
+      const properties = node.arguments[0].properties;
+
       const result = [];
       let chunk = [];
       for (let i = 0; i < properties.length; i += 1) {

--- a/tests/lib/rules/sort-styles.js
+++ b/tests/lib/rules/sort-styles.js
@@ -597,6 +597,34 @@ const tests = {
         },
       ],
     },
+    {
+      code: `
+        StyleSheet.create({
+          myClass: {
+            y: 2,
+            x: 1,
+            z: 3,
+          },
+        })
+        `,
+      errors: [{
+        message: 'Expected style properties to be in ascending order. \'x\' should be before \'y\'.',
+      }],
+    },
+    {
+      code: `
+        export default StyleSheet.create({
+          myClass: {
+            y: 2,
+            x: 1,
+            z: 3,
+          },
+        })
+        `,
+      errors: [{
+        message: 'Expected style properties to be in ascending order. \'x\' should be before \'y\'.',
+      }],
+    },
   ],
 };
 
@@ -616,4 +644,4 @@ const config = {
 tests.valid.forEach(t => Object.assign(t, config));
 tests.invalid.forEach(t => Object.assign(t, config));
 
-ruleTester.run('no-unused-styles', rule, tests);
+ruleTester.run('sort-styles', rule, tests);


### PR DESCRIPTION
Fixes #214

Instead of only looking for `StyleSheet` declarations in `VariableDeclarator` nodes, we check if `CallExpressions` are `StyleSheet.create({...})`. This handles the `export default StyleSheet.create({...})` case and other cases where the style sheet is not assigned to a variable.