### PR TITLE
Add no-unused-styles default import support

### DIFF
--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -101,9 +101,16 @@ const astHelpers = {
       node &&
       node.type === 'CallExpression' &&
       node.callee &&
-      node.callee.object &&
-      node.callee.object.name &&
-      objectNames.includes(node.callee.object.name)
+      node.callee.object && ((
+        node.callee.object.type === 'Identifier' &&
+        node.callee.object.name &&
+        objectNames.includes(node.callee.object.name)
+      ) || (
+        node.callee.object.type === 'MemberExpression' &&
+        node.callee.object.object.type === 'Identifier' &&
+        astHelpers.getImportSource(node.callee.object.object) === 'react-native' &&
+        objectNames.includes(node.callee.object.property.name)
+      ))
     );
   },
 
@@ -460,6 +467,50 @@ const astHelpers = {
       node.property.name
     ) {
       return node.property.name;
+    }
+  },
+
+  getRoot: function (node) {
+    let currentNode = node;
+    while (currentNode && currentNode.parent) {
+      currentNode = currentNode.parent;
+    }
+
+    return currentNode;
+  },
+
+  getImportVariable: function (node) {
+    if (node && node.type === 'ImportDeclaration') {
+      for (let i = 0; node.specifiers; i += 1) {
+        const specifier = node.specifiers[i];
+        if (
+          specifier && (
+            specifier.type === 'ImportDefaultSpecifier' ||
+            specifier.type === 'ImportNamespaceSpecifier'
+          ) &&
+          specifier.local &&
+          specifier.local.type === 'Identifier'
+        ) {
+          return specifier.local.name;
+        }
+      }
+    }
+  },
+
+  getImportSource: function (node) {
+    if (node && node.type === 'Identifier' && node.name) {
+      const rootNode = astHelpers.getRoot(node);
+      if (rootNode && rootNode.body) {
+        for (let i = 0; rootNode.body.length; i += 1) {
+          const bodyNode = rootNode.body[i];
+          if (
+            astHelpers.getImportVariable(bodyNode) === node.name &&
+            bodyNode.source && bodyNode.source.type === 'Literal'
+          ) {
+            return bodyNode.source.value;
+          }
+        }
+      }
     }
   },
 

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -215,6 +215,31 @@ const tests = {
         }
       });
     `,
+  }, {
+    code: `
+      import RN from 'react-native';
+      const styles = RN.StyleSheet.create({
+        name: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+  }, {
+    code: `
+    import React from 'react';
+    import RN from 'react-native';
+      const styles = RN.StyleSheet.create({
+        name: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
   }],
 
   invalid: [{
@@ -276,6 +301,22 @@ const tests = {
     errors: [{
       message: 'Unused style detected: styles.bar',
     }],
+  }, {
+    code: `
+      import RN from 'react-native';
+      const styles = RN.StyleSheet.create({
+        name: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          return <Text>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+    errors: [{
+      message: 'Unused style detected: styles.name',
+    }],
+
   }],
 };
 


### PR DESCRIPTION
This PR adds support for identifying unused styles when `StyleSheet` isn't imported separately, but instead used through the `react-native` default import, for example in

```javascript
import RN from 'react-native';
const styles = RN.StyleSheet.create({});
```

Fixes #227
Replaces #218