### PR TITLE
Add EStyleSheet variables support

### DIFF
--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -18,7 +18,7 @@ module.exports = Components.detect((context) => {
   function reportColorLiterals(colorLiterals) {
     if (colorLiterals) {
       colorLiterals.forEach((style) => {
-        if (style) {
+        if (style && !astHelpers.isEStyleSheetVariable(style.expression)) {
           const expression = util.inspect(style.expression);
           context.report({
             node: style.node,

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -487,6 +487,12 @@ const astHelpers = {
     }
     return false;
   },
+
+  isEStyleSheetVariable: function (expression) {
+    return Object.values(expression).every(
+      value => typeof value === 'string' && value.startsWith('$')
+    );
+  },
 };
 
 module.exports.astHelpers = astHelpers;

--- a/tests/lib/rules/no-color-literals.js
+++ b/tests/lib/rules/no-color-literals.js
@@ -67,6 +67,28 @@ const tests = {
         }
       `,
     },
+    {
+      code: `
+        const styles = EStyleSheet.create({
+            $red: 'red',
+            $blue: 'blue',
+            style1: {
+                color: '$red',
+            },
+            style2: {
+                color: '$blue',
+            }
+        });
+        export default class MyComponent extends Component {
+            render() {
+                const isDanger = true;
+                return <View 
+                           style={[styles.style1, isDanger ? styles.style1 : styles.style2]}
+                       />;
+            }
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -186,6 +208,12 @@ const config = {
       classes: true,
       jsx: true,
     },
+  },
+  settings: {
+    'react-native/style-sheet-object-names': [
+      'StyleSheet',
+      'EStyleSheet',
+    ],
   },
 };
 


### PR DESCRIPTION
Hi!

According to the React Native Extended StyleSheet [documentation](https://github.com/vitalets/react-native-extended-stylesheet#global-variables), styles variables can be strings.

This PR fixes `no-color-literals` rule that will no longer report an error for colors declared as EStyleSheet string variables.