### PR TITLE
Support TypeScript in split-platform-components

### DIFF
--- a/lib/rules/split-platform-components.js
+++ b/lib/rules/split-platform-components.js
@@ -13,10 +13,10 @@ module.exports = function (context) {
   const conflictMessage = 'IOS and Android components can\'t be mixed';
   const iosPathRegex = context.options[0] && context.options[0].iosPathRegex
     ? new RegExp(context.options[0].iosPathRegex)
-    : /\.ios\.js$/;
+    : /\.ios\.[j|t]sx?$/;
   const androidPathRegex = context.options[0] && context.options[0].androidPathRegex
     ? new RegExp(context.options[0].androidPathRegex)
-    : /\.android\.js$/;
+    : /\.android\.[j|t]sx?$/;
 
   function getName(node) {
     if (node.type === 'Property') {


### PR DESCRIPTION
Currently only `.js` files are recognized by the `split-platform-components` rule. This update should allow for TypeScript support as well.