### PR TITLE
fix: don't warn when using eslint v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^3.6.4"
   },
   "peerDependencies": {
-    "eslint": "^3.17.0 || ^4 || ^5 || ^6"
+    "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
This plugin has no issues with eslint 7.x so we should not want when using it.