### PR TITLE
fix: rule/no-single-element-style-arrays - exception when style prop is not an expression

### DIFF
--- a/lib/rules/no-single-element-style-arrays.js
+++ b/lib/rules/no-single-element-style-arrays.js
@@ -37,6 +37,7 @@ module.exports = {
     return {
       JSXAttribute(node) {
         if (node.name.name !== 'style') return;
+        if (!node.value.expression) return;
         if (node.value.expression.type !== 'ArrayExpression') return;
         if (node.value.expression.elements.length === 1) {
           reportNode(node);


### PR DESCRIPTION
This fixes an issue when a React Native component has style prop that can be a string.

The most notable example of this is the default `App.js` (or App.tsx) in a new React Native app (initialized using `expo init`, as recommended by the [RN docs](https://reactnative.dev/docs/environment-setup)). It looks like this:
<img width="739" alt="Screen Shot 2020-07-14 at 16 04 13" src="https://user-images.githubusercontent.com/369384/87484973-7ab72c80-c5ec-11ea-86e2-6c0ebcd1b98d.png">

Notice line 9 which contains: `<StatusBar style="auto" />`

That causes the following exception when running `eslint`:
<img width="1440" alt="Screen Shot 2020-07-14 at 16 11 06" src="https://user-images.githubusercontent.com/369384/87485036-aa663480-c5ec-11ea-843e-348403daf5c3.png">

