### PR TITLE
Fix bug in sort-styles when props included shorthands

### DIFF
--- a/lib/rules/sort-styles.js
+++ b/lib/rules/sort-styles.js
@@ -92,14 +92,9 @@ module.exports = (context) => {
       const prevName = getStylePropertyIdentifier(previous);
       const currentName = getStylePropertyIdentifier(current);
 
-      if (
-        arrayName === 'style properties'
-        && isEitherShortHand(prevName, currentName)
-      ) {
-        return;
-      }
+      const oneIsShorthandForTheOther = arrayName === 'style properties' && isEitherShortHand(prevName, currentName);
 
-      if (!isValidOrder(prevName, currentName)) {
+      if (!oneIsShorthandForTheOther && !isValidOrder(prevName, currentName)) {
         return report(array, arrayName, node, previous, current);
       }
     }

--- a/tests/lib/rules/sort-styles.js
+++ b/tests/lib/rules/sort-styles.js
@@ -194,6 +194,32 @@ const tests = {
       code: `
           const styles = StyleSheet.create({
             myClass: {
+              flex: 1,
+              flexDirection: 'row',
+              backgroundColor: 'red',
+            },
+          })
+          `,
+      output: `
+          const styles = StyleSheet.create({
+            myClass: {
+              backgroundColor: 'red',
+              flex: 1,
+              flexDirection: 'row',
+            },
+          })
+          `,
+      errors: [
+        {
+          message:
+            "Expected style properties to be in ascending order. 'backgroundColor' should be before 'flexDirection'.",
+        },
+      ],
+    },
+    {
+      code: `
+          const styles = StyleSheet.create({
+            myClass: {
               y: 2,
               x: 1,
               z: 3,


### PR DESCRIPTION
If the style properties had a 'isEitherShorthand' case, it would return out of the whole checkIsSorted function instead of continuing the for loop. This caused some properties to not be reported as unsorted.

It would be sufficient to replace `return` with `continue`, but there was a ESLint rule disallowing the usage of continue.

I added a new test case for this scenario.