### PR TITLE
Fix unused style fragment shorthand

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -152,7 +152,7 @@ function componentRule(rule, context) {
       }
 
       const returnsJSX = node[property]
-        && node[property].type === 'JSXElement';
+        && (node[property].type === 'JSXElement' || node[property].type === 'JSXFragment');
       const returnsReactCreateElement = node[property]
         && node[property].callee
         && node[property].callee.property

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -112,7 +112,7 @@ const tests = {
       });
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true, condition2: true };
+          return { condition: true, condition2: true }; 
         },
         render: function() {
           return (
@@ -135,7 +135,7 @@ const tests = {
       });
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true };
+          return { condition: true }; 
         },
         render: function() {
           return (
@@ -175,7 +175,7 @@ const tests = {
     code: `
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true };
+          return { condition: true }; 
         },
         render: function() {
           const myStyle = this.state.condition ? styles.text : styles.text2;

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -112,7 +112,7 @@ const tests = {
       });
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true, condition2: true }; 
+          return { condition: true, condition2: true };
         },
         render: function() {
           return (
@@ -135,7 +135,7 @@ const tests = {
       });
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true }; 
+          return { condition: true };
         },
         render: function() {
           return (
@@ -175,7 +175,7 @@ const tests = {
     code: `
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true }; 
+          return { condition: true };
         },
         render: function() {
           const myStyle = this.state.condition ? styles.text : styles.text2;
@@ -275,6 +275,16 @@ const tests = {
     `,
     errors: [{
       message: 'Unused style detected: styles.bar',
+    }],
+  }, {
+    code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const Hello = () => (<><Text style={styles.b}>Hello</Text></>);
+    `,
+    errors: [{
+      message: 'Unused style detected: styles.text',
     }],
   }],
 };


### PR DESCRIPTION
Components with shorthand Fragments (`<></>`) weren't being traversed in no-unused-styles.

Using these styles:
```
const styles = StyleSheet.create({
  used: {},
  unused: {},
});

```
```
const CorrectlyFails1 = () => {
  return (<Text style={styles.used}>Hello</Text>);
}
```
```
const CorrectlyFails1 = () => {
  return (<React.Fragment><Text style={styles.used}>Hello</Text></React.Fragment>);
}
```
```
const IncorrectlyPasses = () => {
  return (<><Text style={styles.used}>Hello</Text></>);
}
```
