### PR TITLE
Fix null error in no-single-element-style-arrays

### DIFF
--- a/lib/rules/no-single-element-style-arrays.js
+++ b/lib/rules/no-single-element-style-arrays.js
@@ -37,6 +37,7 @@ module.exports = {
     return {
       JSXAttribute(node) {
         if (node.name.name !== 'style') return;
+        if (!node.value) return;
         if (!node.value.expression) return;
         if (node.value.expression.type !== 'ArrayExpression') return;
         if (node.value.expression.elements.length === 1) {


### PR DESCRIPTION
I'm using the ESLint plugin in VSCode, and when I'm in the middle of typing out my component style (e.g. `<View style>`) in VSCode, I'm getting the following error:
```
TypeError: Cannot read property 'expression' of null
Occurred while linting root\src\Component.tsx:72
    at JSXAttribute (root\node_modules\eslint-plugin-react-native\lib\rules\no-single-element-style-arrays.js:40:25)
    at root\node_modules\eslint\lib\linter\safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (root\node_modules\eslint\lib\linter\safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (root\node_modules\eslint\lib\linter\node-event-generator.js:293:26)
    at NodeEventGenerator.applySelectors (root\node_modules\eslint\lib\linter\node-event-generator.js:322:22)
    at NodeEventGenerator.enterNode (root\node_modules\eslint\lib\linter\node-event-generator.js:336:14)
    at CodePathAnalyzer.enterNode (root\node_modules\eslint\lib\linter\code-path-analysis\code-path-analyzer.js:711:23)
    at root\node_modules\eslint\lib\linter\linter.js:954:32
    at Array.forEach (<anonymous>)
```

Although a style attribute with no value is technically not valid, `no-single-element-style-arrays` should silently ignore this and not throw an error.