### PR TITLE
Switch rules to object export style (fixes eslint v8+)

### DIFF
--- a/lib/rules/no-color-literals.js
+++ b/lib/rules/no-color-literals.js
@@ -12,7 +12,7 @@ const styleSheet = require('../util/stylesheet');
 const { StyleSheets } = styleSheet;
 const { astHelpers } = styleSheet;
 
-module.exports = Components.detect((context) => {
+const create = Components.detect((context) => {
   const styleSheets = new StyleSheets();
 
   function reportColorLiterals(colorLiterals) {
@@ -55,4 +55,9 @@ module.exports = Components.detect((context) => {
   };
 });
 
-module.exports.schema = [];
+module.exports = {
+  meta: {
+    schema: [],
+  },
+  create,
+};

--- a/lib/rules/no-inline-styles.js
+++ b/lib/rules/no-inline-styles.js
@@ -12,7 +12,7 @@ const styleSheet = require('../util/stylesheet');
 const { StyleSheets } = styleSheet;
 const { astHelpers } = styleSheet;
 
-module.exports = Components.detect((context) => {
+const create = Components.detect((context) => {
   const styleSheets = new StyleSheets();
 
   function reportInlineStyles(inlineStyles) {
@@ -42,4 +42,9 @@ module.exports = Components.detect((context) => {
   };
 });
 
-module.exports.schema = [];
+module.exports = {
+  meta: {
+    schema: [],
+  },
+  create,
+};

--- a/lib/rules/no-raw-text.js
+++ b/lib/rules/no-raw-text.js
@@ -26,7 +26,7 @@ const elementName = (node, scope) => {
   return identifiers.join('.');
 };
 
-module.exports = (context) => {
+function create(context) {
   const options = context.options[0] || {};
 
   const report = (node) => {
@@ -86,19 +86,24 @@ module.exports = (context) => {
       }
     },
   };
-};
+}
 
-module.exports.schema = [
-  {
-    type: 'object',
-    properties: {
-      skip: {
-        type: 'array',
-        items: {
-          type: 'string',
+module.exports = {
+  meta: {
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          skip: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
         },
+        additionalProperties: false,
       },
-    },
-    additionalProperties: false,
+    ],
   },
-];
+  create,
+};

--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -11,7 +11,7 @@ const styleSheet = require('../util/stylesheet');
 const { StyleSheets } = styleSheet;
 const { astHelpers } = styleSheet;
 
-module.exports = Components.detect((context, components) => {
+const create = Components.detect((context, components) => {
   const styleSheets = new StyleSheets();
   const styleReferences = new Set();
 
@@ -62,4 +62,9 @@ module.exports = Components.detect((context, components) => {
   };
 });
 
-module.exports.schema = [];
+module.exports = {
+  meta: {
+    schema: [],
+  },
+  create,
+};

--- a/lib/rules/sort-styles.js
+++ b/lib/rules/sort-styles.js
@@ -23,7 +23,7 @@ const {
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = (context) => {
+function create(context) {
   const order = context.options[0] || 'asc';
   const options = context.options[1] || {};
   const { ignoreClassNames } = options;
@@ -130,23 +130,28 @@ module.exports = (context) => {
       });
     },
   };
-};
+}
 
-module.exports.fixable = 'code';
-module.exports.schema = [
-  {
-    enum: ['asc', 'desc'],
-  },
-  {
-    type: 'object',
-    properties: {
-      ignoreClassNames: {
-        type: 'boolean',
+module.exports = {
+  meta: {
+    fixable: 'code',
+    schema: [
+      {
+        enum: ['asc', 'desc'],
       },
-      ignoreStyleProperties: {
-        type: 'boolean',
+      {
+        type: 'object',
+        properties: {
+          ignoreClassNames: {
+            type: 'boolean',
+          },
+          ignoreStyleProperties: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
       },
-    },
-    additionalProperties: false,
+    ],
   },
-];
+  create,
+};

--- a/lib/rules/split-platform-components.js
+++ b/lib/rules/split-platform-components.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-module.exports = function (context) {
+function create(context) {
   let reactComponents = [];
   const androidMessage = 'Android components should be placed in android files';
   const iosMessage = 'IOS components should be placed in ios files';
@@ -75,17 +75,23 @@ module.exports = function (context) {
       reportErrors(reactComponents, filename);
     },
   };
-};
+}
 
-module.exports.schema = [{
-  type: 'object',
-  properties: {
-    androidPathRegex: {
-      type: 'string',
-    },
-    iosPathRegex: {
-      type: 'string',
-    },
+module.exports = {
+  meta: {
+    fixable: 'code',
+    schema: [{
+      type: 'object',
+      properties: {
+        androidPathRegex: {
+          type: 'string',
+        },
+        iosPathRegex: {
+          type: 'string',
+        },
+      },
+      additionalProperties: false,
+    }],
   },
-  additionalProperties: false,
-}];
+  create,
+};

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^3.6.4"
   },
   "peerDependencies": {
-    "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7"
+    "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
Fixes https://github.com/Intellicode/eslint-plugin-react-native/issues/298. Verified all tests pass.

From [eslint docs](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#rules-require-metafixable-to-provide-fixes):

> In ESLint v7.0.0, rules that were written as a function (rather than object) were able to provide fixes. In ESLint v8.0.0, only rules written as an object are allowed to provide fixes and must have a meta.fixable property set to either "code" or "whitespace".