### PR TITLE
Feature/styles destructuring support

### DIFF
--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -36,24 +36,9 @@ module.exports = Components.detect((context, components) => {
       }
     },
 
-    ArrayExpression: function (arrayNode) {
-      if (arrayNode && arrayNode.elements && arrayNode.elements.length) {
-        arrayNode.elements
-          .flatMap((node) => {
-            const styleRef = astHelpers.getPotentialStyleReferenceFromArrayExpression(node);
-            return styleRef ? [styleRef] : [];
-          })
-          .forEach((styleRef) => {
-            styleReferences.add(styleRef);
-          });
-      }
-    },
-
-    JSXExpressionContainer: function (node) {
-      const styleRef = astHelpers.getPotentialStyleReferenceFromJSXExpressionContainer(node);
-      if (styleRef) {
-        styleReferences.add(styleRef);
-      }
+    VariableDeclarator: function (node) {
+      const styleRefs = astHelpers.getPotentialDestructuredStyleReferences(node);
+      styleRefs.forEach(styleReferences.add, styleReferences);
     },
 
     CallExpression: function (node) {
@@ -68,9 +53,7 @@ module.exports = Components.detect((context, components) => {
     'Program:exit': function () {
       const list = components.all();
       if (Object.keys(list).length > 0) {
-        styleReferences.forEach((reference) => {
-          styleSheets.markAsUsed(reference);
-        });
+        styleReferences.forEach(styleSheets.markAsUsed, styleSheets);
         reportUnusedStyles(styleSheets.getUnusedReferences());
       }
     },

--- a/lib/rules/no-unused-styles.js
+++ b/lib/rules/no-unused-styles.js
@@ -20,12 +20,7 @@ module.exports = Components.detect((context, components) => {
       if ({}.hasOwnProperty.call(unusedStyles, key)) {
         const styles = unusedStyles[key];
         styles.forEach((node) => {
-          const message = [
-            'Unused style detected: ',
-            key,
-            '.',
-            node.key.name,
-          ].join('');
+          const message = ['Unused style detected: ', key, '.', node.key.name].join('');
 
           context.report(node, message);
         });
@@ -36,6 +31,26 @@ module.exports = Components.detect((context, components) => {
   return {
     MemberExpression: function (node) {
       const styleRef = astHelpers.getPotentialStyleReferenceFromMemberExpression(node);
+      if (styleRef) {
+        styleReferences.add(styleRef);
+      }
+    },
+
+    ArrayExpression: function (arrayNode) {
+      if (arrayNode && arrayNode.elements && arrayNode.elements.length) {
+        arrayNode.elements
+          .flatMap((node) => {
+            const styleRef = astHelpers.getPotentialStyleReferenceFromArrayExpression(node);
+            return styleRef ? [styleRef] : [];
+          })
+          .forEach((styleRef) => {
+            styleReferences.add(styleRef);
+          });
+      }
+    },
+
+    JSXExpressionContainer: function (node) {
+      const styleRef = astHelpers.getPotentialStyleReferenceFromJSXExpressionContainer(node);
       if (styleRef) {
         styleReferences.add(styleRef);
       }

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -484,7 +484,7 @@ const astHelpers = {
       && node.expression.name
       && node.parent
       && node.parent.name
-      && node.parent.name.name === 'style'
+      && ['style', 'textStyle'].includes(node.parent.name.name)
     ) {
       return node.expression.name;
     }

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -1,4 +1,3 @@
-
 'use strict';
 
 /**
@@ -31,10 +30,16 @@ StyleSheets.prototype.markAsUsed = function (fullyQualifiedName) {
   const styleSheetName = nameSplit[0];
   const styleSheetProperty = nameSplit[1];
 
-  if (this.styleSheets[styleSheetName]) {
-    this.styleSheets[styleSheetName] = this
-      .styleSheets[styleSheetName]
-      .filter((property) => property.key.name !== styleSheetProperty);
+  if (nameSplit.length === 1) {
+    Object.keys(this.styleSheets).forEach((key) => {
+      this.styleSheets[key] = this.styleSheets[key].filter(
+        (property) => property.key.name !== styleSheetName
+      );
+    });
+  } else if (this.styleSheets[styleSheetName]) {
+    this.styleSheets[styleSheetName] = this.styleSheets[styleSheetName].filter(
+      (property) => property.key.name !== styleSheetProperty
+    );
   }
 };
 
@@ -86,11 +91,8 @@ StyleSheets.prototype.getObjectExpressions = function () {
   return this.objectExpressions;
 };
 
-
 let currentContent;
-const getSourceCode = (node) => currentContent
-  .getSourceCode(node)
-  .getText(node);
+const getSourceCode = (node) => currentContent.getSourceCode(node).getText(node);
 
 const getStyleSheetObjectNames = (settings) => settings['react-native/style-sheet-object-names'] || ['StyleSheet'];
 
@@ -98,20 +100,17 @@ const astHelpers = {
   containsStyleSheetObject: function (node, objectNames) {
     return Boolean(
       node
-      && node.type === 'CallExpression'
-      && node.callee
-      && node.callee.object
-      && node.callee.object.name
-      && objectNames.includes(node.callee.object.name)
+        && node.type === 'CallExpression'
+        && node.callee
+        && node.callee.object
+        && node.callee.object.name
+        && objectNames.includes(node.callee.object.name)
     );
   },
 
   containsCreateCall: function (node) {
     return Boolean(
-      node
-      && node.callee
-      && node.callee.property
-      && node.callee.property.name === 'create'
+      node && node.callee && node.callee.property && node.callee.property.name === 'create'
     );
   },
 
@@ -119,8 +118,7 @@ const astHelpers = {
     const objectNames = getStyleSheetObjectNames(settings);
 
     return Boolean(
-      astHelpers.containsStyleSheetObject(node, objectNames)
-      && astHelpers.containsCreateCall(node)
+      astHelpers.containsStyleSheetObject(node, objectNames) && astHelpers.containsCreateCall(node)
     );
   },
 
@@ -200,10 +198,12 @@ const astHelpers = {
         case 'Literal':
           return node.value;
         case 'TemplateLiteral':
-          return node.quasis.reduce((result, quasi, index) => result
-            + quasi.value.cooked
-            + astHelpers.getExpressionIdentifier(node.expressions[index]),
-          '');
+          return node.quasis.reduce(
+            (result, quasi, index) => result
+              + quasi.value.cooked
+              + astHelpers.getExpressionIdentifier(node.expressions[index]),
+            ''
+          );
         default:
           return '';
       }
@@ -213,10 +213,7 @@ const astHelpers = {
   },
 
   getStylePropertyIdentifier: function (node) {
-    if (
-      node
-      && node.key
-    ) {
+    if (node && node.key) {
       return astHelpers.getExpressionIdentifier(node.key);
     }
   },
@@ -224,23 +221,20 @@ const astHelpers = {
   isStyleAttribute: function (node) {
     return Boolean(
       node.type === 'JSXAttribute'
-      && node.name
-      && node.name.name
-      && node.name.name.toLowerCase().includes('style')
+        && node.name
+        && node.name.name
+        && node.name.name.toLowerCase().includes('style')
     );
   },
 
   collectStyleObjectExpressions: function (node, context) {
     currentContent = context;
     if (astHelpers.hasArrayOfStyleReferences(node)) {
-      const styleReferenceContainers = node
-        .expression
-        .elements;
+      const styleReferenceContainers = node.expression.elements;
 
-      return astHelpers.collectStyleObjectExpressionFromContainers(
-        styleReferenceContainers
-      );
-    } if (node && node.expression) {
+      return astHelpers.collectStyleObjectExpressionFromContainers(styleReferenceContainers);
+    }
+    if (node && node.expression) {
       return astHelpers.getStyleObjectExpressionFromNode(node.expression);
     }
 
@@ -254,13 +248,9 @@ const astHelpers = {
 
     currentContent = context;
     if (astHelpers.hasArrayOfStyleReferences(node)) {
-      const styleReferenceContainers = node
-        .expression
-        .elements;
+      const styleReferenceContainers = node.expression.elements;
 
-      return astHelpers.collectColorLiteralsFromContainers(
-        styleReferenceContainers
-      );
+      return astHelpers.collectColorLiteralsFromContainers(styleReferenceContainers);
     }
 
     if (node.type === 'ObjectExpression') {
@@ -273,8 +263,9 @@ const astHelpers = {
   collectStyleObjectExpressionFromContainers: function (nodes) {
     let objectExpressions = [];
     nodes.forEach((node) => {
-      objectExpressions = objectExpressions
-        .concat(astHelpers.getStyleObjectExpressionFromNode(node));
+      objectExpressions = objectExpressions.concat(
+        astHelpers.getStyleObjectExpressionFromNode(node)
+      );
     });
 
     return objectExpressions;
@@ -283,8 +274,7 @@ const astHelpers = {
   collectColorLiteralsFromContainers: function (nodes) {
     let colorLiterals = [];
     nodes.forEach((node) => {
-      colorLiterals = colorLiterals
-        .concat(astHelpers.getColorLiteralsFromNode(node));
+      colorLiterals = colorLiterals.concat(astHelpers.getColorLiteralsFromNode(node));
     });
 
     return colorLiterals;
@@ -369,10 +359,13 @@ const astHelpers = {
   },
 
   hasArrayOfStyleReferences: function (node) {
-    return node && Boolean(
-      node.type === 'JSXExpressionContainer'
-      && node.expression
-      && node.expression.type === 'ArrayExpression'
+    return (
+      node
+      && Boolean(
+        node.type === 'JSXExpressionContainer'
+          && node.expression
+          && node.expression.type === 'ArrayExpression'
+      )
     );
   },
 
@@ -408,10 +401,18 @@ const astHelpers = {
             invalid = true;
             obj[p.key.name] = getSourceCode(innerNode);
           }
-        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '-' && p.value.argument.type === 'Literal') {
+        } else if (
+          p.value.type === 'UnaryExpression'
+          && p.value.operator === '-'
+          && p.value.argument.type === 'Literal'
+        ) {
           invalid = true;
           obj[p.key.name] = -1 * p.value.argument.value;
-        } else if (p.value.type === 'UnaryExpression' && p.value.operator === '+' && p.value.argument.type === 'Literal') {
+        } else if (
+          p.value.type === 'UnaryExpression'
+          && p.value.operator === '+'
+          && p.value.argument.type === 'Literal'
+        ) {
           invalid = true;
           obj[p.key.name] = p.value.argument.value;
         }
@@ -443,21 +444,13 @@ const astHelpers = {
   },
 
   getObjectName: function (node) {
-    if (
-      node
-      && node.object
-      && node.object.name
-    ) {
+    if (node && node.object && node.object.name) {
       return node.object.name;
     }
   },
 
   getPropertyName: function (node) {
-    if (
-      node
-      && node.property
-      && node.property.name
-    ) {
+    if (node && node.property && node.property.name) {
       return node.property.name;
     }
   },
@@ -477,11 +470,32 @@ const astHelpers = {
     }
   },
 
+  getPotentialStyleReferenceFromArrayExpression: function (node) {
+    if (node && node.type === 'Identifier' && node.name) {
+      return node.name;
+    }
+  },
+
+  getPotentialStyleReferenceFromJSXExpressionContainer: function (node) {
+    if (
+      node
+      && node.expression
+      && node.expression.type === 'Identifier'
+      && node.expression.name
+      && node.parent
+      && node.parent.name
+      && node.parent.name.name === 'style'
+    ) {
+      return node.expression.name;
+    }
+  },
+
   isEitherShortHand: function (property1, property2) {
     const shorthands = ['margin', 'padding', 'border', 'flex'];
     if (shorthands.includes(property1)) {
       return property2.startsWith(property1);
-    } if (shorthands.includes(property2)) {
+    }
+    if (shorthands.includes(property2)) {
       return property1.startsWith(property2);
     }
     return false;

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -30,13 +30,7 @@ StyleSheets.prototype.markAsUsed = function (fullyQualifiedName) {
   const styleSheetName = nameSplit[0];
   const styleSheetProperty = nameSplit[1];
 
-  if (nameSplit.length === 1) {
-    Object.keys(this.styleSheets).forEach((key) => {
-      this.styleSheets[key] = this.styleSheets[key].filter(
-        (property) => property.key.name !== styleSheetName
-      );
-    });
-  } else if (this.styleSheets[styleSheetName]) {
+  if (this.styleSheets[styleSheetName]) {
     this.styleSheets[styleSheetName] = this.styleSheets[styleSheetName].filter(
       (property) => property.key.name !== styleSheetProperty
     );
@@ -120,6 +114,14 @@ const astHelpers = {
     return Boolean(
       astHelpers.containsStyleSheetObject(node, objectNames) && astHelpers.containsCreateCall(node)
     );
+  },
+
+  getDestructuringAssignmentParts: function (node) {
+    if (node && node.id && node.id.type === 'ObjectPattern' && node.id.properties && node.init) {
+      return [node.init.name, node.id.properties];
+    }
+
+    return [null, null];
   },
 
   getStyleSheetName: function (node) {
@@ -470,24 +472,16 @@ const astHelpers = {
     }
   },
 
-  getPotentialStyleReferenceFromArrayExpression: function (node) {
-    if (node && node.type === 'Identifier' && node.name) {
-      return node.name;
-    }
-  },
+  getPotentialDestructuredStyleReferences: function (node) {
+    const [styleSheetName, properties] = this.getDestructuringAssignmentParts(node);
 
-  getPotentialStyleReferenceFromJSXExpressionContainer: function (node) {
-    if (
-      node
-      && node.expression
-      && node.expression.type === 'Identifier'
-      && node.expression.name
-      && node.parent
-      && node.parent.name
-      && ['style', 'textStyle'].includes(node.parent.name.name)
-    ) {
-      return node.expression.name;
-    }
+    return styleSheetName && properties
+      ? properties.flatMap((property) =>
+          property.key && property.key.type === 'Identifier' && property.key.name
+            ? `${styleSheetName}.${property.key.name}`
+            : []
+        )
+      : [];
   },
 
   isEitherShortHand: function (property1, property2) {

--- a/lib/util/stylesheet.js
+++ b/lib/util/stylesheet.js
@@ -476,11 +476,9 @@ const astHelpers = {
     const [styleSheetName, properties] = this.getDestructuringAssignmentParts(node);
 
     return styleSheetName && properties
-      ? properties.flatMap((property) =>
-          property.key && property.key.type === 'Identifier' && property.key.name
-            ? `${styleSheetName}.${property.key.name}`
-            : []
-        )
+      ? properties.flatMap((property) => (property.key && property.key.type === 'Identifier' && property.key.name
+        ? `${styleSheetName}.${property.key.name}`
+        : []))
       : [];
   },
 

--- a/tests/lib/rules/no-color-literals.js
+++ b/tests/lib/rules/no-color-literals.js
@@ -37,7 +37,7 @@ const tests = {
         export default class MyComponent extends Component {
             render() {
                 const isDanger = true;
-                return <View 
+                return <View
                            style={[styles.style1, isDanger ? styles.style1 : styles.style2]}
                        />;
             }
@@ -57,11 +57,11 @@ const tests = {
         export default class MyComponent extends Component {
             render() {
                 const trueColor = '#fff';
-                const falseColor = '#000' 
-                return <View 
-                   style={[style1, 
-                           this.state.isDanger && {color: falseColor}, 
-                           {color: someBoolean ? trueColor : falseColor }]} 
+                const falseColor = '#000'
+                return <View
+                   style={[style1,
+                           this.state.isDanger && {color: falseColor},
+                           {color: someBoolean ? trueColor : falseColor }]}
                         />;
             }
         }
@@ -79,9 +79,11 @@ const tests = {
           }
         });
       `,
-      errors: [{
-        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
-      }],
+      errors: [
+        {
+          message: "Color literal: { backgroundColor: '#FFFFFF' }",
+        },
+      ],
     },
     {
       code: `
@@ -93,9 +95,11 @@ const tests = {
           }
         });
       `,
-      errors: [{
-        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
-      }],
+      errors: [
+        {
+          message: "Color literal: { backgroundColor: '#FFFFFF' }",
+        },
+      ],
     },
     {
       code: `
@@ -110,9 +114,11 @@ const tests = {
           }
         });
       `,
-      errors: [{
-        message: 'Color literal: { fontColor: \'#000\' }',
-      }],
+      errors: [
+        {
+          message: "Color literal: { fontColor: '#000' }",
+        },
+      ],
     },
     {
       code: `
@@ -124,24 +130,28 @@ const tests = {
           }
         });
       `,
-      errors: [{
-        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
-      }],
+      errors: [
+        {
+          message: "Color literal: { backgroundColor: '#FFFFFF' }",
+        },
+      ],
     },
     {
       code: `
         const Hello = React.createClass({
           render: function() {
-            const someBoolean = false; 
+            const someBoolean = false;
             return <Text style={[styles.text, someBoolean && {backgroundColor: '#FFFFFF'}]}>
               Hello {this.props.name}
              </Text>;
           }
         });
       `,
-      errors: [{
-        message: 'Color literal: { backgroundColor: \'#FFFFFF\' }',
-      }],
+      errors: [
+        {
+          message: "Color literal: { backgroundColor: '#FFFFFF' }",
+        },
+      ],
     },
     {
       code: `
@@ -156,23 +166,23 @@ const tests = {
         });
         export default class MyComponent extends Component {
             render() {
-                return <View 
-                   style={[style1, 
-                           this.state.isDanger && styles.style1, 
-                           {backgroundColor: someBoolean ? '#fff' : '#000'}]} 
+                return <View
+                   style={[style1,
+                           this.state.isDanger && styles.style1,
+                           {backgroundColor: someBoolean ? '#fff' : '#000'}]}
                         />;
             }
         }
       `,
       errors: [
         {
-          message: 'Color literal: { color: \'red\' }',
+          message: "Color literal: { color: 'red' }",
         },
         {
-          message: 'Color literal: { borderBottomColor: \'blue\' }',
+          message: "Color literal: { borderBottomColor: 'blue' }",
         },
         {
-          message: 'Color literal: { backgroundColor: \'someBoolean ? \\\'#fff\\\' : \\\'#000\\\'\' }', //eslint-disable-line
+          message: `Color literal: { backgroundColor: "someBoolean ? '#fff' : '#000'" }`, //eslint-disable-line
         },
       ],
     },

--- a/tests/lib/rules/no-inline-styles.js
+++ b/tests/lib/rules/no-inline-styles.js
@@ -56,11 +56,11 @@ const tests = {
         });
         export default class MyComponent extends Component {
             render() {
-                const trueColor = '#fff'; const falseColor = '#000' 
-                return <View 
-                   style={[style1, 
-                           this.state.isDanger && styles.style1, 
-                           {color: someBoolean ? trueColor : falseColor }]} 
+                const trueColor = '#fff'; const falseColor = '#000'
+                return <View
+                   style={[style1,
+                           this.state.isDanger && styles.style1,
+                           {color: someBoolean ? trueColor : falseColor }]}
                         />;
             }
         }
@@ -154,7 +154,7 @@ const tests = {
       code: `
         const Hello = React.createClass({
           render: function() {
-            const someBoolean = false; 
+            const someBoolean = false;
             return <Text style={[styles.text, someBoolean && {backgroundColor: '#FFFFFF'}]}>
               Hello {this.props.name}
              </Text>;
@@ -177,16 +177,16 @@ const tests = {
         });
         export default class MyComponent extends Component {
             render() {
-                return <View 
-                   style={[style1, 
-                           this.state.isDanger && styles.style1, 
-                           {backgroundColor: someBoolean ? '#fff' : '#000'}]} 
+                return <View
+                   style={[style1,
+                           this.state.isDanger && styles.style1,
+                           {backgroundColor: someBoolean ? '#fff' : '#000'}]}
                         />;
             }
         }
       `,
       errors: [{
-        message: 'Inline style: { backgroundColor: \'someBoolean ? \\\'#fff\\\' : \\\'#000\\\'\' }', //eslint-disable-line
+        message: `Inline style: { backgroundColor: "someBoolean ? '#fff' : '#000'" }`, //eslint-disable-line
       }],
     },
   ],

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -50,7 +50,33 @@ const tests = {
       code: `
       const Hello = React.createClass({
         render: function() {
+          const { name } = styles;
+          return <Text textStyle={name}>Hello {this.props.name}</Text>;
+        }
+      });
+      const styles = StyleSheet.create({
+        name: {}
+      });
+    `,
+    },
+    {
+      code: `
+      const Hello = React.createClass({
+        render: function() {
           return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+      const styles = StyleSheet.create({
+        name: {}
+      });
+    `,
+    },
+    {
+      code: `
+      const Hello = React.createClass({
+        render: function() {
+          const { name } = styles;
+          return <Text textStyle={name}>Hello {this.props.name}</Text>;
         }
       });
       const styles = StyleSheet.create({
@@ -66,6 +92,19 @@ const tests = {
       const Hello = React.createClass({
         render: function() {
           return <Text style={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        name: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          const { name } = styles;
+          return <Text style={name}>Hello {this.props.name}</Text>;
         }
       });
     `,
@@ -91,6 +130,26 @@ const tests = {
     {
       code: `
       const styles = StyleSheet.create({
+        name: {},
+        welcome: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          const { name } = styles;
+          return <Text style={name}>Hello {this.props.name}</Text>;
+        }
+      });
+      const Welcome = React.createClass({
+        render: function() {
+          const { welcome } = styles;
+          return <Text style={welcome}>Welcome</Text>;
+        }
+      });
+    `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
         text: {}
       })
       const Hello = React.createClass({
@@ -99,6 +158,22 @@ const tests = {
         },
         render: function() {
           return <Text style={[styles.text, textStyle]}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const Hello = React.createClass({
+        propTypes: {
+          textStyle: Text.propTypes.style,
+        },
+        render: function() {
+          const { text } = styles;
+          return <Text style={[text, textStyle]}>Hello {this.props.name}</Text>;
         }
       });
     `,
@@ -118,6 +193,30 @@ const tests = {
         render: function() {
           return (
             <Text style={[styles.text, styles2.text, textStyle]}>
+             Hello {this.props.name}
+            </Text>
+           );
+        }
+      });
+    `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const styles2 = StyleSheet.create({
+        text: {}
+      })
+      const Hello = React.createClass({
+        propTypes: {
+          textStyle: Text.propTypes.style,
+        },
+        render: function() {
+          const { text } = styles;
+          const { text: text2 } = styles2;
+          return (
+            <Text style={[text, text2, textStyle]}>
              Hello {this.props.name}
             </Text>
            );
@@ -151,6 +250,30 @@ const tests = {
     {
       code: `
       const styles = StyleSheet.create({
+        text: {}
+      });
+      const Hello = React.createClass({
+        getInitialState: function() {
+          return { condition: true, condition2: true };
+        },
+        render: function() {
+          const { text } = styles;
+          return (
+            <Text
+              style={[
+                this.state.condition &&
+                this.state.condition2 &&
+                text]}>
+              Hello {this.props.name}
+            </Text>
+          );
+        }
+      });
+    `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
         text: {},
         text2: {},
       });
@@ -161,6 +284,27 @@ const tests = {
         render: function() {
           return (
             <Text style={[this.state.condition ? styles.text : styles.text2]}>
+              Hello {this.props.name}
+            </Text>
+          );
+        }
+      });
+    `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        text: {},
+        text2: {},
+      });
+      const Hello = React.createClass({
+        getInitialState: function() {
+          return { condition: true };
+        },
+        render: function() {
+          const { text, text2 } = styles;
+          return (
+            <Text style={[this.state.condition ? text : text2]}>
               Hello {this.props.name}
             </Text>
           );
@@ -184,6 +328,27 @@ const tests = {
           };
           render() {
               return <View style={this.props.isDanger ? styles.style1 : styles.style2} />;
+          }
+      }
+    `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+          style1: {
+              color: 'red',
+          },
+          style2: {
+              color: 'blue',
+          }
+      });
+      export default class MyComponent extends Component {
+          static propTypes = {
+              isDanger: PropTypes.bool
+          };
+          render() {
+            const { style1, style2 } = styles;
+              return <View style={this.props.isDanger ? style1 : style2} />;
           }
       }
     `,
@@ -218,6 +383,28 @@ const tests = {
     },
     {
       code: `
+      const Hello = React.createClass({
+        getInitialState: function() {
+          return { condition: true };
+        },
+        render: function() {
+          const { text, text2 } = styles;
+          const myStyle = this.state.condition ? text : text2;
+          return (
+              <Text style={myStyle}>
+                  Hello {this.props.name}
+              </Text>
+          );
+        }
+      });
+      const styles = StyleSheet.create({
+        text: {},
+        text2: {},
+      });
+    `,
+    },
+    {
+      code: `
       const additionalStyles = {};
       const styles = StyleSheet.create({
         name: {},
@@ -226,6 +413,21 @@ const tests = {
       const Hello = React.createClass({
         render: function() {
           return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+    },
+    {
+      code: `
+      const additionalStyles = {};
+      const styles = StyleSheet.create({
+        name: {},
+        ...additionalStyles
+      });
+      const Hello = React.createClass({
+        render: function() {
+          const { name } = styles;
+          return <Text textStyle={name}>Hello {this.props.name}</Text>;
         }
       });
     `,
@@ -242,6 +444,19 @@ const tests = {
       });
     `,
     },
+    {
+      code: `
+      const styles = OtherStyleSheet.create({
+        name: {},
+      });
+      const Hello = React.createClass({
+        render: function() {
+          const { name } = styles;
+          return <Text textStyle={name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+    },
   ],
 
   invalid: [
@@ -253,6 +468,24 @@ const tests = {
       const Hello = React.createClass({
         render: function() {
           return <Text style={styles.b}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.text',
+        },
+      ],
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const Hello = React.createClass({
+        render: function() {
+          const { b } = styles;
+          return <Text style={b}>Hello {this.props.name}</Text>;
         }
       });
     `,
@@ -286,9 +519,47 @@ const tests = {
         foo: {},
         bar: {},
       })
+      class Foo extends React.Component {
+        render() {
+          const { foo } = styles;
+          return <View style={foo}/>;
+        }
+      }
+    `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.bar',
+        },
+      ],
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        foo: {},
+        bar: {},
+      })
       class Foo extends React.PureComponent {
         render() {
           return <View style={styles.foo}/>;
+        }
+      }
+    `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.bar',
+        },
+      ],
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        foo: {},
+        bar: {},
+      })
+      class Foo extends React.PureComponent {
+        render() {
+          const { foo } = styles;
+          return <View style={foo}/>;
         }
       }
     `,
@@ -318,10 +589,45 @@ const tests = {
     },
     {
       code: `
+      const styles = OtherStyleSheet.create({
+        foo: {},
+        bar: {},
+      })
+      class Foo extends React.PureComponent {
+        render() {
+          const { foo } = styles;
+          return <View style={foo}/>;
+        }
+      }
+    `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.bar',
+        },
+      ],
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {}
       })
       const Hello = () => (<><Text style={styles.b}>Hello</Text></>);
+    `,
+      errors: [
+        {
+          message: 'Unused style detected: styles.text',
+        },
+      ],
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        text: {}
+      })
+      const Hello = () => {
+        const { b } = styles;
+        return <><Text style={styles.b}>Hello</Text></>;
+      }
     `,
       errors: [
         {

--- a/tests/lib/rules/no-unused-styles.js
+++ b/tests/lib/rules/no-unused-styles.js
@@ -20,8 +20,9 @@ require('babel-eslint');
 
 const ruleTester = new RuleTester();
 const tests = {
-  valid: [{
-    code: `
+  valid: [
+    {
+      code: `
       const styles = StyleSheet.create({
         name: {}
       });
@@ -31,8 +32,22 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        name: {}
+      });
+      const Hello = React.createClass({
+        render: function() {
+          const { name } = styles;
+          return <Text textStyle={name}>Hello {this.props.name}</Text>;
+        }
+      });
+    `,
+    },
+    {
+      code: `
       const Hello = React.createClass({
         render: function() {
           return <Text textStyle={styles.name}>Hello {this.props.name}</Text>;
@@ -42,8 +57,9 @@ const tests = {
         name: {}
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         name: {}
       });
@@ -53,8 +69,9 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         name: {},
         welcome: {}
@@ -70,8 +87,9 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {}
       })
@@ -84,8 +102,9 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {}
       })
@@ -105,14 +124,15 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {}
       });
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true, condition2: true }; 
+          return { condition: true, condition2: true };
         },
         render: function() {
           return (
@@ -127,15 +147,16 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {},
         text2: {},
       });
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true }; 
+          return { condition: true };
         },
         render: function() {
           return (
@@ -146,8 +167,9 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
           style1: {
               color: 'red',
@@ -165,17 +187,19 @@ const tests = {
           }
       }
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {}
       })
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const Hello = React.createClass({
         getInitialState: function() {
-          return { condition: true }; 
+          return { condition: true };
         },
         render: function() {
           const myStyle = this.state.condition ? styles.text : styles.text2;
@@ -191,8 +215,9 @@ const tests = {
         text2: {},
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const additionalStyles = {};
       const styles = StyleSheet.create({
         name: {},
@@ -204,8 +229,9 @@ const tests = {
         }
       });
     `,
-  }, {
-    code: `
+    },
+    {
+      code: `
       const styles = OtherStyleSheet.create({
         name: {},
       });
@@ -215,10 +241,12 @@ const tests = {
         }
       });
     `,
-  }],
+    },
+  ],
 
-  invalid: [{
-    code: `
+  invalid: [
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {}
       })
@@ -228,11 +256,14 @@ const tests = {
         }
       });
     `,
-    errors: [{
-      message: 'Unused style detected: styles.text',
-    }],
-  }, {
-    code: `
+      errors: [
+        {
+          message: 'Unused style detected: styles.text',
+        },
+      ],
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         foo: {},
         bar: {},
@@ -243,11 +274,14 @@ const tests = {
         }
       }
     `,
-    errors: [{
-      message: 'Unused style detected: styles.bar',
-    }],
-  }, {
-    code: `
+      errors: [
+        {
+          message: 'Unused style detected: styles.bar',
+        },
+      ],
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         foo: {},
         bar: {},
@@ -258,11 +292,14 @@ const tests = {
         }
       }
     `,
-    errors: [{
-      message: 'Unused style detected: styles.bar',
-    }],
-  }, {
-    code: `
+      errors: [
+        {
+          message: 'Unused style detected: styles.bar',
+        },
+      ],
+    },
+    {
+      code: `
       const styles = OtherStyleSheet.create({
         foo: {},
         bar: {},
@@ -273,20 +310,26 @@ const tests = {
         }
       }
     `,
-    errors: [{
-      message: 'Unused style detected: styles.bar',
-    }],
-  }, {
-    code: `
+      errors: [
+        {
+          message: 'Unused style detected: styles.bar',
+        },
+      ],
+    },
+    {
+      code: `
       const styles = StyleSheet.create({
         text: {}
       })
       const Hello = () => (<><Text style={styles.b}>Hello</Text></>);
     `,
-    errors: [{
-      message: 'Unused style detected: styles.text',
-    }],
-  }],
+      errors: [
+        {
+          message: 'Unused style detected: styles.text',
+        },
+      ],
+    },
+  ],
 };
 
 const config = {


### PR DESCRIPTION
I've added a support for the use of destructuring assignment for styles:

For example:
```js
      const styles = StyleSheet.create({
        name: {}
      });
      const Hello = React.createClass({
        render: function() {
          const { name } = styles;
          return <Text style={name}>Hello {this.props.name}</Text>;
        }
      });
```
