### PR TITLE
feat: option for rule 'no-inline-styles'

### DIFF
--- a/docs/rules/no-inline-styles.md
+++ b/docs/rules/no-inline-styles.md
@@ -50,3 +50,9 @@ const Welcome = React.createClass({
   }
 });
 ```
+
+#### This rule has an object option:
+
+- "allowStylePropertiesLessThan" – allow style properties count less than a specific number. for e.g. `2` will allow `{fontSize: 15}` but not `{fontSize: 15, fontColor: 'white'}`
+
+

--- a/lib/rules/no-inline-styles.js
+++ b/lib/rules/no-inline-styles.js
@@ -12,13 +12,15 @@ const styleSheet = require('../util/stylesheet');
 const { StyleSheets } = styleSheet;
 const { astHelpers } = styleSheet;
 
-const create = Components.detect((context) => {
+module.exports = Components.detect((context) => {
+  const options = context.options[0] || {};
   const styleSheets = new StyleSheets();
 
   function reportInlineStyles(inlineStyles) {
     if (inlineStyles) {
       inlineStyles.forEach((style) => {
         if (style) {
+          if (options.allowStylePropertiesLessThan && Object.keys(style.expression).length < options.allowStylePropertiesLessThan) return;
           const expression = util.inspect(style.expression);
           context.report({
             node: style.node,
@@ -42,9 +44,13 @@ const create = Components.detect((context) => {
   };
 });
 
-module.exports = {
-  meta: {
-    schema: [],
-  },
-  create,
-};
+module.exports.schema = [
+  {
+    type: 'object',
+    properties: {
+      allowStylePropertiesLessThan: {
+        type: 'number',
+      },
+    },
+  }
+];


### PR DESCRIPTION
Added an option for rule 'no-inline-styles'.

- "allowStylePropertiesLessThan" – allow style properties count less than a specific number. for e.g. `2` will allow `{fontSize: 15}` but not `{fontSize: 15, fontColor: 'white'}`

Tested on my local machine and works.