### PR TITLE
feat: allow regular expressions in skip property

### DIFF
--- a/lib/rules/no-raw-text.js
+++ b/lib/rules/no-raw-text.js
@@ -50,7 +50,7 @@ function create(context) {
   const hasOnlyLineBreak = (value) => /^[\r\n\t\f\v]+$/.test(value.replace(/ /g, ''));
 
   const scope = context.getScope();
-  const getValidation = (node) => !allowedElements.includes(elementName(node.parent, scope));
+  const getValidation = (node) => !allowedElements.some((el) => new RegExp(`^${el}$`).test(elementName(node.parent, scope)));
 
   return {
     Literal(node) {

--- a/tests/lib/rules/no-raw-text.js
+++ b/tests/lib/rules/no-raw-text.js
@@ -107,6 +107,14 @@ const tests = {
     },
     {
       code: `
+        const Title = ({ children }) => (<Title.Text>{children}</Title.Text>);
+        Title.Text = ({ children }) => (<Text>{children}</Text>);
+        <Title.Text>This is the title</Title.Text>
+      `,
+      options: [{ skip: ['Title.*'] }],
+    },
+    {
+      code: `
         export default class MyComponent extends Component {
           render() {
             return (<View><Text style={{color: 'red'}}>some text</Text></View>);


### PR DESCRIPTION
According to the Issue #248, this PR adds support of using regular expression in skip parameter in config file, as [suggested here.](https://github.com/Intellicode/eslint-plugin-react-native/issues/248#issuecomment-673130844)

It helps to avoid linter warnings in custom components. You can do `"skip": ["CustomComponentl.*"]` to avoid warning in nested structure of your components.